### PR TITLE
found this buglet on my codebase... makes similarly_associated always return an array instead of nil

### DIFF
--- a/lib/bullet/registry/association.rb
+++ b/lib/bullet/registry/association.rb
@@ -9,7 +9,7 @@ module Bullet
       def similarly_associated( base, associations )
         @registry.select do |key, value|
           key.include?( base ) and value == associations
-        end.collect( &:first ).flatten!
+        end.collect( &:first ).flatten
       end
     end
   end


### PR DESCRIPTION
removes ! from flatten, was causing this procedure to return nil instead of [] - which caused a nil deref downstream.
