### PR TITLE
better feedback

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -85,8 +85,9 @@ module Bullet
       responses.join( "\n" )
     end
 
-    def perform_out_of_channel_notifications
+    def perform_out_of_channel_notifications(env = {})
       for_each_active_notifier_with_notification do |notification|
+        notification.url = [env['HTTP_HOST'], env['REQUEST_URI']].compact.join
         notification.notify_out_of_channel
       end
     end

--- a/lib/bullet/notification/base.rb
+++ b/lib/bullet/notification/base.rb
@@ -1,7 +1,7 @@
 module Bullet
   module Notification
     class Base
-      attr_accessor :notifier
+      attr_accessor :notifier, :url
       attr_reader :base_class, :associations, :path
 
       def initialize( base_class, associations, path = nil )
@@ -15,6 +15,10 @@ module Bullet
 
       def body
       end
+      
+      def whoami
+        "user: " << `whoami`.chomp
+      end
 
       def body_with_caller
         body
@@ -25,7 +29,7 @@ module Bullet
       end
 
       def full_notice
-        @full_notice ||= title + "\n" + body_with_caller
+        [whoami, url, title, body_with_caller].compact.join("\n")
       end
 
       def notify_inline

--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -16,7 +16,7 @@ module Bullet
           response_body = response.body << Bullet.gather_inline_notifications
           headers['Content-Length'] = response_body.length.to_s
         end
-        Bullet.perform_out_of_channel_notifications
+        Bullet.perform_out_of_channel_notifications(env)
       end
       response_body ||= response.body
       Bullet.end_request


### PR DESCRIPTION
My use case is using bullet to collect performance issues from other developers on my team and from our staging system.  I'm using xmpp to deliver the errors to me, but without knowing who to talk to or what page the error was on, it's really hard to follow-up with it.

This patch adds the user and url to the messages.  The only downside is that it adds it to every notification type, not just xmpp; I couldn't think of an easy way to do that.

Anyway, in case you think it's interesting, here's a pull request.
