### PR TITLE
Fixes the Rails version detector regex for Rails 3.1

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -2,7 +2,7 @@ require 'set'
 require 'uniform_notifier'
 
 module Bullet
-  if Rails.version =~ /^3.0/
+  if Rails.version =~ /^3.[01]/
     autoload :ActiveRecord, 'bullet/active_record3'
   else
     autoload :ActiveRecord, 'bullet/active_record2'


### PR DESCRIPTION
Fixes the Rails version detector regex to load the AR3 Bullet module on Rails 3.1, rather than the AR2 Bullet module. Should fix issue #44.
