### PR TITLE
ActiveRecord 3.1 HasManyAssociation bug

### DIFF
--- a/lib/bullet/active_record31.rb
+++ b/lib/bullet/active_record31.rb
@@ -85,8 +85,8 @@ module Bullet
       ::ActiveRecord::Associations::HasManyAssociation.class_eval do
         alias_method :origin_has_cached_counter?, :has_cached_counter?
 
-        def has_cached_counter?(reflection)
-          result = origin_has_cached_counter?(reflection)
+        def has_cached_counter?(*args)
+          result = origin_has_cached_counter?(*args)
           Bullet::Detector::Counter.add_counter_cache(@owner, @reflection.name) unless result
           result
         end


### PR DESCRIPTION
ActiveRecord::Associations::HasManyAssociation#has_cached_counter? method requires a parameter in 3.1
This causes errors when using bullet with the mentioned version.
This commit should fix the problem by just accepting and passing that argument.
