### PR TITLE
Preserve initial response object if possible

### DIFF
--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -11,6 +11,7 @@ module Bullet
       status, headers, response = @app.call(env)
       return [status, headers, response] if empty?(response)
 
+      response_body = nil
       if Bullet.notification?
         if status == 200 and !response.body.frozen? and check_html?(headers, response)
           response_body = response.body << Bullet.gather_inline_notifications
@@ -18,10 +19,9 @@ module Bullet
         end
         Bullet.perform_out_of_channel_notifications(env)
       end
-      response_body ||= response.body
       Bullet.end_request
       no_browser_cache(headers) if Bullet.disable_browser_cache
-      [status, headers, [response_body]]
+      [status, headers, response_body ? [response_body] : response]
     end
 
     # fix issue if response's body is a Proc

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -1,0 +1,40 @@
+require File.dirname(__FILE__) + '/../spec_helper'
+
+
+describe Bullet::Rack do
+  let(:middleware) { Bullet::Rack.new app }
+  let(:app) { AppDouble.new }
+
+  describe "#call" do
+    context "when Bullet is enabled" do
+      before(:each) { Bullet.enable = true }
+
+      it "should invoke Bullet.start_request" do
+        Bullet.should_receive(:start_request)
+        middleware.call([])
+      end
+
+      it "should invoke Bullet.end_request" do
+        Bullet.should_receive(:end_request)
+        middleware.call([])
+      end
+
+      it "should return original response body" do
+        expected_response = ResponseDouble.new "Actual body"
+        app.response = expected_response
+        status, headers, response = middleware.call([])
+        response.should eq expected_response
+      end
+    end
+
+    context "when Bullet is disabled" do
+      before(:each) { Bullet.enable = false }
+      after(:each) { Bullet.enable = true }
+
+      it "should not call Bullet.start_request" do
+        Bullet.should_not_receive(:start_request)
+        middleware.call([])
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require 'rubygems'
 require 'rspec'
 require 'rspec/autorun'
@@ -75,5 +76,59 @@ module Bullet
         end
       end
     end
+  end
+end
+
+class AppDouble
+  def call env
+    env = @env
+    [ status, headers, response ]
+  end
+
+  def status= status
+    @status = status
+  end
+
+  def headers= headers
+    @headers = headers
+  end
+
+  def headers
+    @headers ||= {}
+    @headers
+  end
+
+  def response= response
+    @response = response
+  end
+
+  private
+  def status
+    @status || 200
+  end
+
+  def response
+    @response || ResponseDouble.new
+  end
+end
+
+class ResponseDouble
+  def initialize actual_body = nil
+    @actual_body = actual_body
+  end
+
+  def body
+    @body ||= "Hello world!"
+  end
+
+  def body= body
+    @body = body
+  end
+
+  def each
+    yield body
+  end
+
+  def close
   end
 end


### PR DESCRIPTION
The Bullet middleware currently serves responses by rewrapping `response.body`.

In development mode Rails 3.2 (haven't checked earlier versions) serves bundled assets as a `Sprockets::BundledAsset`. This object's `body` method returns just the content of the original file without the concatenated requirements.

This change preserves whatever response object was returned from the underlying app unless some rewriting occurred.
