### PR TITLE
fix issue (receiving 0 byte files) if response is a ActionDispatch::Response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tags
 .bundle
 *.gem
 benchmark_profile*
+/nbproject/private/


### PR DESCRIPTION
Hi, 

fix issue (receiving 0 byte files) if response is a ActionDispatch::Response

In my case response was invoked with the send_file command:
send_file "/tmp/myfile.zip", :type => 'application/zip', :filename=>'myfile.zip'

Looks that it's bad to call response.body if response is ActionDispatch::Response
