### PR TITLE
Allow for attributes in the html tag.

### DIFF
--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -37,7 +37,7 @@ module Bullet
     end
 
     def html_request?(headers, response)
-      headers['Content-Type'] && headers['Content-Type'].include?('text/html') && response.body.include?("<html>")
+      headers['Content-Type'] && headers['Content-Type'].include?('text/html') && response.body.include?("<html")
     end
 
     def no_browser_cache(headers)

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -22,6 +22,12 @@ module Bullet
         middleware.should be_html_request(headers, response)
       end
 
+      it "should be true if Content-Type is text/html and http body contains html tag with attributes" do
+        headers = {"Content-Type" => "text/html"}
+        response = stub(:body => "<html attr='hello'><head></head><body></body></html>")
+        middleware.should be_html_request(headers, response)
+      end
+
       it "should be false if there is no Content-Type header" do
         headers = {}
         response = stub(:body => "<html><head></head><body></body></html>")


### PR DESCRIPTION
Obviously not the best way to test for this, but I didn't want to involve a
regexp or a dom parser. The old way didn't work for our app or any app that
puts attributes on html (like facebook open graph attributes)
