### PR TITLE
Ignore older versions of mongoid

### DIFF
--- a/lib/bullet/dependency.rb
+++ b/lib/bullet/dependency.rb
@@ -3,7 +3,7 @@ module Bullet
     def mongoid?
       @mongoid ||= begin
                      require 'mongoid'
-                     true
+                     mongoid_version.present?
                    rescue LoadError
                      false
                    end


### PR DESCRIPTION
We're using an unsupported version of mongoid, but I would still like to use bullet for active record. This change ignores mongoid if the version is unsupported so it can still be used for active record.
