### PR TITLE
Make logging directory relative to project root, not execution directory

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -58,7 +58,7 @@ module Bullet
 
     def bullet_logger=(active)
       if active
-        bullet_log_file = File.open("#{Rails.root}/log/bullet.log", 'a+')
+        bullet_log_file = File.open("#{rails2? ? RAILS_ROOT : Rails.root.to_s}/log/bullet.log", 'a+')
         bullet_log_file.sync = true
         UniformNotifier.customized_logger = bullet_log_file
       end

--- a/lib/bullet/dependency.rb
+++ b/lib/bullet/dependency.rb
@@ -83,5 +83,9 @@ module Bullet
     def mongoid3?
       ::Mongoid::VERSION =~ /\A3/
     end
+
+    def rails2?
+      ::Rails::VERSION::MAJOR < 3
+    end
   end
 end


### PR DESCRIPTION
In any project that includes bullet, executing any code outside of the main directory would fail (In my case, import/export scripts in the 'scripts' directory that were used to generate CSVs from Models for import into external services).  By making this path use the project root as a starting point rather than a relative path, so it should fix this issue.

The code should be safe for all current versions of Rails back through 2 - it does have to detect the rails version to ensure it uses the correct method of determining the root.
