### PR TITLE
Bullet fails when response body is Rack::File, issue #62

### DIFF
--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -28,7 +28,9 @@ module Bullet
     def empty?(response)
       # response may be ["Not Found"], ["Move Permanently"], etc.
       (response.is_a?(Array) && response.size <= 1) ||
-        !response.respond_to?(:body) || response.body.empty?
+        !response.respond_to?(:body) ||
+        !response.body.respond_to?(:empty?) ||
+        response.body.empty?
     end
 
     # if send file?


### PR DESCRIPTION
Implemented kikito's fix:

```
# lib/bullet/rack.rb
def empty?(response)
  # response may be ["Not Found"], ["Move Permanently"], etc.
  (response.is_a?(Array) && response.size <= 1) ||
    !response.respond_to?(:body) || 
    !response.body.respond_to?(:empty?) ||
    response.body.empty?
end
```
