### PR TITLE
cleaner formatting with colors for Base.notify_out_of_channel 

### DIFF
--- a/lib/bullet/ext/string.rb
+++ b/lib/bullet/ext/string.rb
@@ -2,4 +2,16 @@ class String
   def bullet_class_name
     self.sub(/:[^:]*?$/, "")
   end
+
+  def bullet_color(color, options = {})
+    background = options[:background] || options[:bg] || false
+    style = options[:style]
+    offsets = ["gray","red", "green", "yellow", "blue", "magenta", "cyan","white"]
+    styles = ["normal","bold","dark","italic","underline","xx","xx","underline","xx","strikethrough"]
+    start = background ? 40 : 30
+    color_code = start + (offsets.index(color) || 8)
+    style_code = styles.index(style) || 0
+    "\e[#{style_code};#{color_code}m#{self}\e[0m"
+  end 
+
 end

--- a/lib/bullet/notification/counter_cache.rb
+++ b/lib/bullet/notification/counter_cache.rb
@@ -8,6 +8,9 @@ module Bullet
       def title
         "Need Counter Cache"
       end
+
+      def caller_list; '' end
+      
     end
   end
 end

--- a/lib/bullet/notification/n_plus_one_query.rb
+++ b/lib/bullet/notification/n_plus_one_query.rb
@@ -10,6 +10,10 @@ module Bullet
       def body_with_caller
         "#{body}\n#{call_stack_messages}"
       end
+      
+      def caller_list
+        "#{call_stack_messages}"
+      end
 
       def body
         "#{klazz_associations_str}\n  Add to your finder: #{associations_str}"
@@ -21,7 +25,7 @@ module Bullet
 
       protected
         def call_stack_messages
-          @callers.unshift('N+1 Query method call stack').join( "\n  " )
+          "  " + @callers.unshift('N+1 Query method call stack').join( "\n  " )
         end
     end
   end

--- a/lib/bullet/notification/unused_eager_loading.rb
+++ b/lib/bullet/notification/unused_eager_loading.rb
@@ -8,6 +8,9 @@ module Bullet
       def title
         "Unused Eager Loading #{@path ? "in #{@path}" : 'detected'}"
       end
+
+      def caller_list; '' end
+
     end
   end
 end


### PR DESCRIPTION
Near as I can tell, Base.notify_out_of_channel only affects bullet and rails logs, so I made it easier to scan for and read. 
