### PR TITLE
Adds ActiveSupport dependency and delegation require

### DIFF
--- a/bullet.gemspec
+++ b/bullet.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
+  s.add_dependency "activesupport"
   s.add_dependency "uniform_notifier"
 
   s.files         = `git ls-files`.split("\n")

--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -1,3 +1,4 @@
+require "active_support/core_ext/module/delegation"
 require 'set'
 require 'uniform_notifier'
 require 'bullet/ext/object'


### PR DESCRIPTION
I am working with Bullet against Sinatra and got a failure to start my app with the following stacktrace...

```
NoMethodError: undefined method `delegate' for #<Class:Bullet>
    __singleton__ at C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/bullet-4.6.0/lib/bullet.rb:31
           Bullet at C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/bullet-4.6.0/lib/bullet.rb:27
           (root) at C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/bullet-4.6.0/lib/bullet.rb:7
          require at org/jruby/RubyKernel.java:1054
           (root) at C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/bundler-1.3.5/lib/bundler/runtime.rb:1
             each at org/jruby/RubyArray.java:1617
          require at C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/bundler-1.3.5/lib/bundler/runtime.rb:72
             each at org/jruby/RubyArray.java:1617
          require at C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/bundler-1.3.5/lib/bundler/runtime.rb:70
          require at C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/bundler-1.3.5/lib/bundler/runtime.rb:59
          require at C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/bundler-1.3.5/lib/bundler.rb:132
          require at org/jruby/RubyKernel.java:1054
          require at C:/Ruby/jruby-1.7.4/lib/ruby/shared/rubygems/custom_require.rb:36
           (root) at C:/Projects/basscamp/basscamp.rb:4
    instance_eval at org/jruby/RubyBasicObject.java:1735
           (root) at config.ru:1
  new_from_string at config.ru:1
             eval at org/jruby/RubyKernel.java:1093
       initialize at C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/builder.rb:55
  new_from_string at config.ru:0
  new_from_string at C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/builder.rb:49
       parse_file at C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/builder.rb:40
              app at C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/puma-2.0.1-java/lib/puma/configuration.rb:83
       run_single at C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/puma-2.0.1-java/lib/puma/cli.rb:428
             load at org/jruby/RubyKernel.java:1073
           (root) at C:\Ruby\jruby-1.7.4\bin\puma:23

```

Tracking back to [this](https://github.com/flyerhzm/bullet/blob/master/lib/bullet.rb#L30) line it's clear that `bullet.rb` is attempting to use the `delegate` method in ActiveSupport but does state that this is required in gemspec and as a require definition.

This is masked by other gems that already loading this ActiveSupport module, e.g. if you happen to have `factory_girl` in the same bundle group as `bullet` then you won't see a problem
