### PR TITLE
Mongoid: Metadata accessor was renamed.

### DIFF
--- a/lib/bullet/mongoid4x.rb
+++ b/lib/bullet/mongoid4x.rb
@@ -44,7 +44,7 @@ module Bullet
         alias_method :origin_set_relation, :set_relation
 
         def set_relation(name, relation)
-          if relation && relation.metadata.macro !~ /embed/
+          if relation && relation.relation_metadata.macro !~ /embed/
             Bullet::Detector::NPlusOneQuery.call_association(self, name)
           end
           origin_set_relation(name, relation)


### PR DESCRIPTION
Since metadata was a common name in applications, we renamed it in
Mongoid 4 master to #relation_metadata.
