### PR TITLE
[BUGFIX] Fix Travis error with the json gem.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,4 @@ gemfile:
 env: DB=sqlite
 services: mongodb
 before_install:
-  - gem uninstall json
   - gem install bundler


### PR DESCRIPTION
Starting from build 158, Travis builds error with the following message:

$ gem uninstall json
ERROR:  While executing gem ... (Gem::InstallError)
    gem "json" cannot be uninstalled because it is a default gem
The command "gem uninstall json" failed and exited with 1 during before_install.
Your build has been stopped.

This change removes the "gem uninstall json" command from .travis.yml.
