### PR TITLE
Remove tableize from whitelist association

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -66,7 +66,7 @@ module Bullet
 
     def add_whitelist(options)
       @whitelist[options[:type]][options[:class_name].classify] ||= []
-      @whitelist[options[:type]][options[:class_name].classify] << options[:association].to_s.tableize.to_sym
+      @whitelist[options[:type]][options[:class_name].classify] << options[:association].to_s.to_sym
     end
 
     def get_whitelist_associations(type, class_name)


### PR DESCRIPTION
With this it's possible to whitelist singular associations. See also #144.
