### PR TITLE
Add `stacktrace_includes` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ config.after_initialize do
   Bullet.rails_logger = true
   Bullet.airbrake = true
   Bullet.add_footer = true
+  Bullet.stacktrace_includes = [ 'your_gem', 'your_middleware' ]
 end
 ```
 
@@ -71,9 +72,10 @@ The code above will enable all seven of the Bullet notification systems:
 * `Bullet.xmpp`: send XMPP/Jabber notifications to the receiver indicated. Note that the code will currently not handle the adding of contacts, so you will need to make both accounts indicated know each other manually before you will receive any notifications. If you restart the development server frequently, the 'coming online' sound for the bullet account may start to annoy - in this case set :show_online_status to false; you will still get notifications, but the bullet account won't announce it's online status anymore.
 * `Bullet.raise`: raise errors, useful for making your specs fail unless they have optimized queries
 * `Bullet.add_footer`: adds the details in the bottom left corner of the page
+* `Bullet.stacktrace_includes`: include paths with any of these substrings in the stack trace, even if they are not in your main app
 
 Bullet also allows you to disable n_plus_one_query, unused_eager_loading
-and counter_cache detectors respectively
+and counter_cache detectors respectively.
 
 ```ruby
 Bullet.n_plus_one_query_enable = false

--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -25,7 +25,7 @@ module Bullet
   end
 
   class << self
-    attr_writer :enable, :n_plus_one_query_enable, :unused_eager_loading_enable, :counter_cache_enable
+    attr_writer :enable, :n_plus_one_query_enable, :unused_eager_loading_enable, :counter_cache_enable, :stacktrace_includes
     attr_reader :notification_collector, :whitelist
     attr_accessor :add_footer
 
@@ -62,6 +62,10 @@ module Bullet
 
     def counter_cache_enable?
       self.enable? && !!@counter_cache_enable
+    end
+
+    def stacktrace_includes
+      @stacktrace_includes || []
     end
 
     def add_whitelist(options)

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -50,7 +50,10 @@ module Bullet
           def caller_in_project
             app_root = rails? ? Rails.root.to_s : Dir.pwd
             vendor_root = app_root + "/vendor"
-            caller.select { |c| c.include?(app_root) && !c.include?(vendor_root) }
+            caller.select do |c|
+              c.include?(app_root) && !c.include?(vendor_root) ||
+              Bullet.stacktrace_includes.any? { |include| c.include?(include) }
+            end
           end
 
           def possible?(bullet_ar_key)

--- a/lib/bullet/notification/n_plus_one_query.rb
+++ b/lib/bullet/notification/n_plus_one_query.rb
@@ -21,7 +21,7 @@ module Bullet
 
       protected
         def call_stack_messages
-          @callers.unshift('N+1 Query method call stack').join( "\n  " )
+          (['N+1 Query method call stack'] + @callers).join( "\n  " )
         end
     end
   end

--- a/spec/bullet/detector/n_plus_one_query_spec.rb
+++ b/spec/bullet/detector/n_plus_one_query_spec.rb
@@ -93,6 +93,34 @@ module Bullet
         end
       end
 
+      context ".caller_in_project" do
+        it "should include only paths that are in the project" do
+          in_project = File.join(Dir.pwd, 'abc', 'abc.rb')
+          not_in_project = '/def/def.rb'
+
+          expect(NPlusOneQuery).to receive(:caller).and_return([in_project, not_in_project])
+          expect(NPlusOneQuery).to receive(:conditions_met?).with(@post.bullet_ar_key, :association).and_return(true)
+          expect(NPlusOneQuery).to receive(:create_notification).with([in_project], "Post", :association)
+          NPlusOneQuery.call_association(@post, :association)
+        end
+
+        context "stacktrace_includes" do
+          before { Bullet.stacktrace_includes = [ 'def' ] }
+          after { Bullet.stacktrace_includes = nil }
+
+          it "should include paths that are in the stacktrace_include list" do
+            in_project = File.join(Dir.pwd, 'abc', 'abc.rb')
+            included_gem = '/def/def.rb'
+            excluded_gem = '/ghi/ghi.rb'
+
+            expect(NPlusOneQuery).to receive(:caller).and_return([in_project, included_gem, excluded_gem])
+            expect(NPlusOneQuery).to receive(:conditions_met?).with(@post.bullet_ar_key, :association).and_return(true)
+            expect(NPlusOneQuery).to receive(:create_notification).with([in_project, included_gem], "Post", :association)
+            NPlusOneQuery.call_association(@post, :association)
+          end
+        end
+      end
+
       context ".add_possible_objects" do
         it "should add possible objects" do
           NPlusOneQuery.add_possible_objects([@post, @post2])

--- a/spec/bullet/notification/n_plus_one_query_spec.rb
+++ b/spec/bullet/notification/n_plus_one_query_spec.rb
@@ -6,6 +6,7 @@ module Bullet
       subject { NPlusOneQuery.new([["caller1", "caller2"]], Post, [:comments, :votes], "path") }
 
       it { expect(subject.body_with_caller).to eq("  Post => [:comments, :votes]\n  Add to your finder: :include => [:comments, :votes]\nN+1 Query method call stack\n  caller1\n  caller2") }
+      it { expect([ subject.body_with_caller, subject.body_with_caller]).to eq([ "  Post => [:comments, :votes]\n  Add to your finder: :include => [:comments, :votes]\nN+1 Query method call stack\n  caller1\n  caller2", "  Post => [:comments, :votes]\n  Add to your finder: :include => [:comments, :votes]\nN+1 Query method call stack\n  caller1\n  caller2" ]) }
       it { expect(subject.body).to eq("  Post => [:comments, :votes]\n  Add to your finder: :include => [:comments, :votes]") }
       it { expect(subject.title).to eq("N+1 Query in path") }
     end


### PR DESCRIPTION
I have a Rails engine that makes database queries.
For people like me, it's nice to be able to tell Bullet
to include your own engine (or anything else you want)
in the stack trace. This code implements that capability.

Also fixed a bug where the "N+1 Query method call stack"
message was being shown multiple times if `call_stack_messages`
was called multiple times.

Tests pass.
