### PR TITLE
Fix Mongoid4 error

### DIFF
--- a/lib/bullet/mongoid4x.rb
+++ b/lib/bullet/mongoid4x.rb
@@ -44,7 +44,7 @@ module Bullet
         alias_method :origin_set_relation, :set_relation
 
         def set_relation(name, relation)
-          if relation && relation.relation_metadata.macro !~ /embed/
+          if relation && relation.relation_metadata && relation.relation_metadata.macro !~ /embed/
             Bullet::Detector::NPlusOneQuery.call_association(self, name)
           end
           origin_set_relation(name, relation)


### PR DESCRIPTION
I'm not entirely sure why, but the objects passed through here on Mongoid4 are not always relations, and so do not always have a relation_metadata.
