### PR TITLE
Applied keyword argument fixes on Ruby 2.2.0

### DIFF
--- a/lib/bullet/active_record3x.rb
+++ b/lib/bullet/active_record3x.rb
@@ -93,7 +93,7 @@ module Bullet
       ::ActiveRecord::Associations::HasManyAssociation.class_eval do
         alias_method :origin_has_cached_counter?, :has_cached_counter?
 
-        def has_cached_counter?(reflection = reflection)
+        def has_cached_counter?(reflection = reflection())
           result = origin_has_cached_counter?(reflection)
           Bullet::Detector::CounterCache.add_counter_cache(owner, reflection.name) unless result
           result

--- a/lib/bullet/active_record4.rb
+++ b/lib/bullet/active_record4.rb
@@ -93,7 +93,7 @@ module Bullet
       ::ActiveRecord::Associations::HasManyAssociation.class_eval do
         alias_method :origin_has_cached_counter?, :has_cached_counter?
 
-        def has_cached_counter?(reflection = reflection)
+        def has_cached_counter?(reflection = reflection())
           result = origin_has_cached_counter?(reflection)
           Bullet::Detector::CounterCache.add_counter_cache(owner, reflection.name) unless result
           result

--- a/lib/bullet/active_record41.rb
+++ b/lib/bullet/active_record41.rb
@@ -86,7 +86,7 @@ module Bullet
       ::ActiveRecord::Associations::HasManyAssociation.class_eval do
         alias_method :origin_has_cached_counter?, :has_cached_counter?
 
-        def has_cached_counter?(reflection = reflection)
+        def has_cached_counter?(reflection = reflection())
           result = origin_has_cached_counter?(reflection)
           Bullet::Detector::CounterCache.add_counter_cache(owner, reflection.name) unless result
           result


### PR DESCRIPTION
Ruby 2.2.0 will change keyword arguments behavior. rails already fixed this changes. I found same code in bullet and fixed it. 

see also.
- https://bugs.ruby-lang.org/issues/9593
- https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/45272
- https://github.com/rails/rails/blob/4-0-stable/activerecord/lib/active_record/associations/has_many_association.rb#L76
