### PR TITLE
double quotes and footer html notification style fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec
 
@@ -7,9 +7,9 @@ gem 'sqlite3', platforms: [:ruby]
 gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
 gem 'activerecord-import'
 
-gem "rspec"
-gem "guard"
-gem "guard-rspec"
+gem 'rspec'
+gem 'guard'
+gem 'guard-rspec'
 
 gem 'coveralls', require: false
 

--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -67,7 +67,7 @@ style="position: fixed; bottom: 0pt; left: 0pt; cursor: pointer; border-style: s
  -moz-border-top-colors: none; -moz-border-right-colors: none; -moz-border-bottom-colors: none;
  -moz-border-left-colors: none; -moz-border-image: none; border-width: 2pt 2pt 0px 0px;
  padding: 5px; border-radius: 0pt 10pt 0pt 0px; background: none repeat scroll 0% 0% rgba(200, 200, 200, 0.8);
- color: rgb(119, 119, 119); font-size: 18px;"
+ color: rgb(119, 119, 119); font-size: 18px; font-family: 'Arial', sans-serif; z-index:9999;"
 EOF
     end
   end


### PR DESCRIPTION
Hey,
I noticed if layout has fixed elements then bullet's HTML notification looks like this:
![bullet-before_fixes](https://cloud.githubusercontent.com/assets/5034850/3349252/870f1a5c-f95a-11e3-8c48-42ff17ebc99a.png)

I changed styles a little bit and now it will always look correctly.
![bullet_after-fixes](https://cloud.githubusercontent.com/assets/5034850/3349253/8723e2fc-f95a-11e3-91a0-ce9d23ee105d.png)

Best regards,
Oskar
