### PR TITLE
Compact all records before sending them to preloaders_on

### DIFF
--- a/lib/bullet/active_record41.rb
+++ b/lib/bullet/active_record41.rb
@@ -25,9 +25,9 @@ module Bullet
         alias_method :origin_preloaders_on, :preloaders_on
 
         def preloaders_on(association, records, scope)
+          records.compact!
           if records.first.class.name !~ /^HABTM_/
             records.each do |record|
-              next unless record
               Bullet::Detector::Association.add_object_associations(record, association)
             end
             Bullet::Detector::UnusedEagerLoading.add_eager_loadings(records, association)


### PR DESCRIPTION
This is an update to #173 / #175. I realize that preloaders_on would still fail if records come in as [nil]. Further looking at Rails code it is actually handled [here](https://github.com/rails/rails/blob/a335e10347e30b885d077cd9e638ee8840ed164a/activerecord/lib/active_record/associations/preloader.rb#L143) for both weeding out nil records and setting class names. Assuming that the current assumption `records.first.class.name !~ /^HABTM_/` still holds (since, if you look at that block of code, it specifically says that "Not all records have the same class") then I think we're good.
