### PR TITLE
warning: `*' interpreted as argument prefix

### DIFF
--- a/lib/bullet/detector/unused_eager_loading.rb
+++ b/lib/bullet/detector/unused_eager_loading.rb
@@ -47,7 +47,7 @@ module Bullet
             end
           end
 
-          eager_loadings.add *to_add if to_add
+          eager_loadings.add(*to_add) if to_add
           to_merge.each { |k,val| eager_loadings.merge k, val }
           to_delete.each { |k| eager_loadings.delete k }
 


### PR DESCRIPTION
Adding a () to eliminate a ruby warning that `*` could be parsed as an operator.
