### PR TITLE
Fix Object#bullet_key performance regression

### DIFF
--- a/lib/bullet/ext/object.rb
+++ b/lib/bullet/ext/object.rb
@@ -1,6 +1,6 @@
 class Object
   def bullet_key
-    [self.class, self.primary_key_value].join(':')
+    "#{self.class}:#{self.primary_key_value}"
   end
 
   def primary_key_value


### PR DESCRIPTION
When Array#join is calling in jruby, self.class#to_str is called, which is missing in Class (BasicObject#method_missing is called). 
Thus this call affects performance and tests become up to 3 times slower.
Array#join add additional delay to perform #bullet_key also.
