### PR TITLE
Don't crash when following a has_one association to nil

### DIFF
--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -34,7 +34,7 @@ module Bullet
         def add_impossible_object(object)
           return unless Bullet.start?
           return unless Bullet.n_plus_one_query_enable?
-          return unless object.primary_key_value
+          return unless object.try(:primary_key_value)
 
           Bullet.debug("Detector::NPlusOneQuery#add_impossible_object", "object: #{object.bullet_key}")
           impossible_objects.add object.bullet_key

--- a/spec/integration/active_record4/association_spec.rb
+++ b/spec/integration/active_record4/association_spec.rb
@@ -524,6 +524,10 @@ if !mongoid? && active_record4?
 
       expect(Bullet::Detector::Association).to be_completely_preloading_associations
     end
+
+    it "should allow null values for has_one" do
+      expect(User.all.map(&:submission)).to include(nil)
+    end
   end
 
   describe Bullet::Detector::Association, "call one association that in possible objects" do

--- a/spec/support/sqlite_seed.rb
+++ b/spec/support/sqlite_seed.rb
@@ -81,6 +81,7 @@ module Support
 
       user1 = User.create(:name => 'user1', :category => category1)
       user2 = User.create(:name => 'user2', :category => category1)
+      user3 = User.create(:name => 'user3', :category => category1)
 
       submission1 = user1.create_submission(:name => "submission1")
       submission2 = user2.create_submission(:name => "submission2")


### PR DESCRIPTION
Bullet is trying to log the result of any has_one call
as an 'impossible_object', but it blows up looking for
nil.id if the result of has_one is a nil. This is a
regression since e94c6a3.