### PR TITLE
don't execute query when running to_sql

### DIFF
--- a/lib/bullet/active_record41.rb
+++ b/lib/bullet/active_record41.rb
@@ -40,6 +40,7 @@ module Bullet
         # add includes in scope
         alias_method :origin_find_with_associations, :find_with_associations
         def find_with_associations
+          return origin_find_with_associations { |r| yield r } if block_given?
           records = origin_find_with_associations
           associations = (eager_load_values + includes_values).uniq
           records.each do |record|

--- a/lib/bullet/active_record42.rb
+++ b/lib/bullet/active_record42.rb
@@ -57,6 +57,7 @@ module Bullet
         # add includes in scope
         alias_method :origin_find_with_associations, :find_with_associations
         def find_with_associations
+          return origin_find_with_associations { |r| yield r } if block_given?
           records = origin_find_with_associations
           associations = (eager_load_values + includes_values).uniq
           records.each do |record|


### PR DESCRIPTION
in AR 4.1 and 4.2, to_sql calls find_with_associations
to attach relevant joins so that the produced SQL matches
the sql actually used when running the query. Bullet's
monkey-patch of find_with_associations calls the original
without a block so it actually passes the query to
the DB connection and runs it.

This commit simply branches the monkey-patch on
block_given? to make it consistent with AR's
definition of the same method. To wit, when
find_with_associations is called by a block, it
yields a new relation with the correct associations
joined and doesn't pass the query on to the DB.