### PR TITLE
Send backtrace to uniform_notifier

### DIFF
--- a/lib/bullet/notification/n_plus_one_query.rb
+++ b/lib/bullet/notification/n_plus_one_query.rb
@@ -15,6 +15,12 @@ module Bullet
         "N+1 Query #{@path ? "in #{@path}" : 'detected'}"
       end
 
+      def notification_data
+        super.merge(
+          :backtrace => @callers
+        )
+      end
+
       protected
         def call_stack_messages
           (['N+1 Query method call stack'] + @callers).join( "\n  " )


### PR DESCRIPTION
I think we can send backtrace of N+1 problem to uniform_notifier.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/flyerhzm/bullet/218)
<!-- Reviewable:end -->
