### PR TITLE
1.8 compatible deletgated available notifiers

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -29,7 +29,9 @@ module Bullet
     attr_reader :notification_collector, :whitelist
     attr_accessor :add_footer, :orm_pathches_applied
 
-    delegate *UniformNotifier::AVAILABLE_NOTIFIERS.map { |notifier| "#{notifier}=" }, :to => UniformNotifier
+    available_notifiers = UniformNotifier::AVAILABLE_NOTIFIERS.map { |notifier| "#{notifier}=" }
+    available_notifiers << { :to => UniformNotifier }
+    delegate *available_notifiers
 
     def raise=(should_raise)
       UniformNotifier.raise=(should_raise ? Notification::UnoptimizedQueryError : false)


### PR DESCRIPTION
a484c0c329 dynamically mapped the available notifiers, breaking 1.8.7
compatibility:

    /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:72:in `require':
    /home/vagrant/gems/ruby/1.8/gems/bullet-4.14.5/lib/bullet.rb:32: syntax
    error, unexpected tSYMBEG, expecting tAMPER (SyntaxError)
    ...|notifier| "#{notifier}=" }, :to => UniformNotifier
                                  ^
    /home/vagrant/gems/ruby/1.8/gems/bullet-4.14.5/lib/bullet.rb:165: syntax
    error, unexpected kDO_BLOCK, expecting kEND
          notification_collector.collection.each do |notification|
                                                   ^
    /home/vagrant/gems/ruby/1.8/gems/bullet-4.14.5/lib/bullet.rb:172: syntax
    error, unexpected kDO_BLOCK, expecting kEND
    ...ector.collection.inject({}) do |warnings, notification|
                                  ^
    /home/vagrant/gems/ruby/1.8/gems/bullet-4.14.5/lib/bullet.rb:172: syntax
    error, unexpected '|', expecting '='
    /home/vagrant/gems/ruby/1.8/gems/bullet-4.14.5/lib/bullet.rb:196: syntax
    error, unexpected kDO_BLOCK, expecting kEND
            UniformNotifier.active_notifiers.each do |notifier|
                                                    ^
    /home/vagrant/gems/ruby/1.8/gems/bullet-4.14.5/lib/bullet.rb:197: syntax
    error, unexpected kDO_BLOCK, expecting kEND
              notification_collector.collection.each do |notification|
                                                       ^
    /home/vagrant/gems/ruby/1.8/gems/bullet-4.14.5/lib/bullet.rb:201: syntax
    error, unexpected kEND, expecting $end
            from /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:72:in `require'
            from /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:70:in `each'
            from /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:70:in `require'
            from /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:59:in `each'
            from /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:59:in `require'
            from /usr/lib/ruby/vendor_ruby/bundler.rb:132:in `require'
            from /home/vagrant/alaveteli/config/application.rb:9
            from
    /home/vagrant/gems/ruby/1.8/gems/railties-3.2.21/lib/rails/commands.rb:39:in
     `require'
            from
    /home/vagrant/gems/ruby/1.8/gems/railties-3.2.21/lib/rails/commands.rb:39
            from script/rails:6:in `require'
            from script/rails:6