### PR TITLE
Fixed NoMethodError in Bullet.warning

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -169,6 +169,7 @@ module Bullet
     end
 
     def warnings
+      return unless notification?
       notification_collector.collection.inject({}) do |warnings, notification|
         warning_type = notification.class.to_s.split(':').last.tableize
         warnings[warning_type] ||= []


### PR DESCRIPTION
I've got
```
NoMethodError: undefined method `collection' for nil:NilClass
from gems/ruby-2.2.1/bundler/gems/bullet-dd48c2515d3c/lib/bullet.rb:172:in `warnings'
```
when invoking `Bullet.warnings` and no warnings have been occurred.