### PR TITLE
Update object.rb

### DIFF
--- a/lib/bullet/ext/object.rb
+++ b/lib/bullet/ext/object.rb
@@ -7,7 +7,11 @@ class Object
     if self.class.respond_to?(:primary_key) && self.class.primary_key
       self.send self.class.primary_key
     else
-      self.id
+      if self.respond_to?(:id)
+        self.id
+      else
+        nil
+      end
     end
   end
 end


### PR DESCRIPTION
I had exception 
undefined method `id' for nil:NilClass
in object.rb because my model have next code:

class Marketer < ActiveRecord::Base
  # ...
  belongs_to        :oauth_application, :class_name => "Doorkeeper::Application"
  # ...
end 

This code worked pre rails 4.2 , now it doesn't. My pull request fixes this.

