### PR TITLE
fix undefined method `id' for nil:NilClass error in Object#primary_key_value

### DIFF
--- a/lib/bullet/ext/object.rb
+++ b/lib/bullet/ext/object.rb
@@ -7,7 +7,7 @@ class Object
     if self.class.respond_to?(:primary_key) && self.class.primary_key
       self.send self.class.primary_key
     else
-      self.id
+      self.respond_to?(:id) && self.id
     end
   end
 end


### PR DESCRIPTION
This might crash the application while dealing with models having nil relations (self = nil).