### PR TITLE
Fixes circular argument reference error for AR 3x for Ruby > 2.2.x

### DIFF
--- a/lib/bullet/active_record3x.rb
+++ b/lib/bullet/active_record3x.rb
@@ -143,7 +143,7 @@ module Bullet
       ::ActiveRecord::Associations::HasManyAssociation.class_eval do
         alias_method :origin_has_cached_counter?, :has_cached_counter?
 
-        def has_cached_counter?(reflection = reflection)
+        def has_cached_counter?(reflection = reflection())
           result = origin_has_cached_counter?(reflection)
           if Bullet.start?
             Bullet::Detector::CounterCache.add_counter_cache(owner, reflection.name) unless result


### PR DESCRIPTION
Using Ruby >=  2.2.x, whenever Bullet would check if a model has a cache_counter, it would error out with `undefined method 'name' for nil:NilClass`. 

It seems to be an issue with the way that Ruby 2.2 warns about circular argument references

```
=> Booting WEBrick
=> Rails 3.2.21 application starting in development on http://0.0.0.0:3000
=> Call with -d to detach
=> Ctrl-C to shutdown server
/bullet/lib/bullet/active_record3x.rb:146: warning: circular argument reference - reflection
[2015-06-04 12:40:19] INFO  WEBrick 1.3.1
[2015-06-04 12:40:19] INFO  ruby 2.2.2 (2015-04-13) [x86_64-darwin14]
[2015-06-04 12:40:19] INFO  WEBrick::HTTPServer#start: pid=7964 port=3000
```