### PR TITLE
Do not report association queries immediately after object creation to require a preload

### DIFF
--- a/lib/bullet/active_record4.rb
+++ b/lib/bullet/active_record4.rb
@@ -21,6 +21,16 @@ module Bullet
         end
       end
 
+      ::ActiveRecord::Persistence.class_eval do
+        def save_with_bullet(*args, &proc)
+          was_new_record = new_record?
+          save_without_bullet(*args, &proc).tap do |result|
+            Bullet::Detector::NPlusOneQuery.add_impossible_object(self) if result && was_new_record
+          end
+        end
+        alias_method_chain :save, :bullet
+      end
+
       ::ActiveRecord::Associations::Preloader.class_eval do
         # include query for one to many associations.
         # keep this eager loadings.

--- a/lib/bullet/active_record42.rb
+++ b/lib/bullet/active_record42.rb
@@ -21,6 +21,16 @@ module Bullet
         end
       end
 
+      ::ActiveRecord::Persistence.class_eval do
+        def save_with_bullet(*args, &proc)
+          was_new_record = new_record?
+          save_without_bullet(*args, &proc).tap do |result|
+            Bullet::Detector::NPlusOneQuery.add_impossible_object(self) if result && was_new_record
+          end
+        end
+        alias_method_chain :save, :bullet
+      end
+
       ::ActiveRecord::Relation.class_eval do
         alias_method :origin_to_a, :to_a
         # if select a collection of objects, then these objects have possible to cause N+1 query.

--- a/spec/integration/active_record4/association_spec.rb
+++ b/spec/integration/active_record4/association_spec.rb
@@ -560,6 +560,27 @@ if !mongoid? && active_record4?
     end
   end
 
+  describe Bullet::Detector::Association, "query immediately after creation" do
+    context "document => children" do
+      it 'should not detect non preload associations' do
+        document1 = Document.new
+        document1.children.build
+        document1.save
+
+        document2 = Document.new(parent: document1)
+        document2.save
+        document2.parent
+
+        document1.children.each.first
+
+        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
+        expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
+
+        expect(Bullet::Detector::Association).to be_completely_preloading_associations
+      end
+    end
+  end
+
   describe Bullet::Detector::Association, "STI" do
     context "page => author" do
       it "should detect non preload associations" do


### PR DESCRIPTION
Fixes #243.