### PR TITLE
Rename to mongoid 5.0.0-beta.

### DIFF
--- a/Gemfile.mongoid-5.0
+++ b/Gemfile.mongoid-5.0
@@ -5,7 +5,7 @@ gemspec
 gem 'rails', '~> 4.0.0'
 gem 'sqlite3', platforms: [:ruby]
 gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
-gem 'mongoid', '~> 5.0.0', github: 'mongoid'
+gem 'mongoid', '~> 5.0.0.beta', github: 'mongoid'
 
 gem "rspec"
 


### PR DESCRIPTION
mongoid 5 is currently in prerelease, so this specifier is needed to use that version from the repository. Introduced by mongoid/mongoid@507d7a794f6edd5f2b1a2b86c922340f3cf7d9c2.