### PR TITLE
start? should check enabled?

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -132,7 +132,7 @@ module Bullet
     end
 
     def start?
-      Thread.current[:bullet_start]
+      enable? && Thread.current[:bullet_start]
     end
 
     def notification_collector

--- a/spec/bullet_spec.rb
+++ b/spec/bullet_spec.rb
@@ -38,4 +38,16 @@ describe Bullet, focused: true do
       end
     end
   end
+
+  describe '#start?' do
+    context 'when bullet is disabled' do
+      before(:each) do
+        Bullet.enable = false
+      end
+
+      it 'should not be started' do
+        expect(Bullet).not_to be_start
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,6 +58,7 @@ if active_record?
 
     config.before(:example) do
       Bullet.start_request
+      Bullet.enable = true
     end
 
     config.after(:example) do


### PR DESCRIPTION
Fixes #247.

I'm not sure if this is the best way to do it -- it seems every detector checks start?