### PR TITLE
Reduce object count

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -16,6 +16,9 @@ module Bullet
   autoload :Registry, 'bullet/registry'
   autoload :NotificationCollector, 'bullet/notification_collector'
 
+  BULLET_DEBUG = 'BULLET_DEBUG'.freeze
+  TRUE = 'true'.freeze
+
   if defined? Rails::Railtie
     class BulletRailtie < Rails::Railtie
       initializer "bullet.configure_rails_initialization" do |app|
@@ -98,7 +101,7 @@ module Bullet
     end
 
     def debug(title, message)
-      puts "[Bullet][#{title}] #{message}" if ENV['BULLET_DEBUG'] == 'true'
+      puts "[Bullet][#{title}] #{message}" if ENV[BULLET_DEBUG] == TRUE
     end
 
     def start_request

--- a/lib/bullet/active_record3.rb
+++ b/lib/bullet/active_record3.rb
@@ -1,5 +1,7 @@
 module Bullet
   module ActiveRecord
+    LOAD_TARGET = 'load_target'.freeze
+
     def self.enable
       require 'active_record'
       ::ActiveRecord::Relation.class_eval do
@@ -138,7 +140,7 @@ module Bullet
           # avoid stack level too deep
           result = origin_load_target
           if Bullet.start?
-            Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name) unless caller.any? { |c| c.include?("load_target") }
+            Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name) unless caller.any? { |c| c.include?(LOAD_TARGET) }
             Bullet::Detector::NPlusOneQuery.add_possible_objects(result)
           end
           result

--- a/spec/bullet_spec.rb
+++ b/spec/bullet_spec.rb
@@ -50,4 +50,39 @@ describe Bullet, focused: true do
       end
     end
   end
+
+  describe '#debug' do
+    before(:each) do
+      $stdout = StringIO.new
+    end
+
+    after(:each) do
+      $stdout = STDOUT
+    end
+
+    context 'when debug is enabled' do
+      before(:each) do
+        ENV['BULLET_DEBUG'] = 'true'
+      end
+
+      after(:each) do
+        ENV['BULLET_DEBUG'] = 'false'
+      end
+
+      it 'should output debug information' do
+        Bullet.debug('debug_message', 'this is helpful information')
+
+        expect($stdout.string)
+          .to eq("[Bullet][debug_message] this is helpful information\n")
+      end
+    end
+
+    context 'when debug is disabled' do
+      it 'should output debug information' do
+        Bullet.debug('debug_message', 'this is helpful information')
+
+        expect($stdout.string).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
I was using `rack-mini-profiler` on my application and noticed that `bullet` was creating a large number of strings to be garbage collected. This is a simple change that will greatly reduce the number of strings that need to be garbage collected.

Before the change
151209 : load_target
4355 : BULLET_DEBUG
4874 : true

After the change
519 : true

For this request, more than 160000 strings were saved from being created.