### PR TITLE
Add stacktrace_excludes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ config.after_initialize do
   Bullet.rollbar = true
   Bullet.add_footer = true
   Bullet.stacktrace_includes = [ 'your_gem', 'your_middleware' ]
+  Bullet.stacktrace_excludes = [ 'their_gem', 'their_middleware' ]
   Bullet.slack = { webhook_url: 'http://some.slack.url', foo: 'bar' }
 end
 ```
@@ -83,6 +84,7 @@ The code above will enable all seven of the Bullet notification systems:
 * `Bullet.raise`: raise errors, useful for making your specs fail unless they have optimized queries
 * `Bullet.add_footer`: adds the details in the bottom left corner of the page
 * `Bullet.stacktrace_includes`: include paths with any of these substrings in the stack trace, even if they are not in your main app
+* `Bullet.stacktrace_excludes`: ignore paths with any of these substrings in the stack trace, even if they are not in your main app.
 * `Bullet.slack`: add notifications to slack
 
 Bullet also allows you to disable any of its detectors.

--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -28,7 +28,7 @@ module Bullet
   end
 
   class << self
-    attr_writer :enable, :n_plus_one_query_enable, :unused_eager_loading_enable, :counter_cache_enable, :stacktrace_includes
+    attr_writer :enable, :n_plus_one_query_enable, :unused_eager_loading_enable, :counter_cache_enable, :stacktrace_includes, :stacktrace_excludes
     attr_reader :notification_collector, :whitelist
     attr_accessor :add_footer, :orm_pathches_applied
 
@@ -74,6 +74,10 @@ module Bullet
 
     def stacktrace_includes
       @stacktrace_includes || []
+    end
+
+    def stacktrace_excludes
+      @stacktrace_excludes || []
     end
 
     def add_whitelist(options)

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -15,7 +15,7 @@ module Bullet
           add_call_object_associations(object, associations)
 
           Bullet.debug("Detector::NPlusOneQuery#call_association", "object: #{object.bullet_key}, associations: #{associations}")
-          if conditions_met?(object, associations)
+          if !excluded_stacktrace_path? && conditions_met?(object, associations)
             Bullet.debug("detect n + 1 query", "object: #{object.bullet_key}, associations: #{associations}")
             create_notification caller_in_project, object.class.to_s, associations
           end
@@ -94,6 +94,12 @@ module Bullet
             caller.select do |c|
               c.include?(app_root) && !c.include?(vendor_root) ||
               Bullet.stacktrace_includes.any? { |include| c.include?(include) }
+            end
+          end
+
+          def excluded_stacktrace_path?
+            Bullet.stacktrace_excludes.any? do |excluded_path|
+              caller_in_project.any? { |c| c.include?(excluded_path) }
             end
           end
       end

--- a/spec/bullet/detector/n_plus_one_query_spec.rb
+++ b/spec/bullet/detector/n_plus_one_query_spec.rb
@@ -85,6 +85,21 @@ module Bullet
           expect(NPlusOneQuery).not_to receive(:create_notification).with("Post", :association)
           NPlusOneQuery.call_association(@post, :association)
         end
+
+        context "stacktrace_excludes" do
+          before { Bullet.stacktrace_excludes = [ 'def' ] }
+          after { Bullet.stacktrace_excludes = nil }
+
+          it "should not create notification when stacktrace contains paths that are in the exclude list" do
+            in_project = File.join(Dir.pwd, 'abc', 'abc.rb')
+            included_path = '/ghi/ghi.rb'
+            excluded_path = '/def/def.rb'
+
+            expect(NPlusOneQuery).to receive(:caller).and_return([in_project, included_path, excluded_path])
+            expect(NPlusOneQuery).to_not receive(:create_notification)
+            NPlusOneQuery.call_association(@post, :association)
+          end
+        end
       end
 
       context ".caller_in_project" do


### PR DESCRIPTION
Hi,

We had a need to exclude n+1 detection based on the caller stack trace, as some of the n+1 detection occuring was not whitelistable using the standard whitelist object/association feature.  I added an option called `stacktrace_excludes` to mirror the `stacktrace_includes` option that already exists.

Please let me know your thoughts.

Thanks for the great tool!