### PR TITLE
[UnusedEagerLoading] multiple eager loading query include same objects 

### DIFF
--- a/lib/bullet/detector/unused_eager_loading.rb
+++ b/lib/bullet/detector/unused_eager_loading.rb
@@ -27,27 +27,25 @@ module Bullet
           Bullet.debug("Detector::UnusedEagerLoading#add_eager_loadings", "objects: #{objects.map(&:bullet_key).join(', ')}, associations: #{associations}")
           bullet_keys = objects.map(&:bullet_key)
 
-          to_add = nil
-          to_merge, to_delete = [], []
+          to_add, to_merge, to_delete = [], [], []
           eager_loadings.each do |k, v|
             key_objects_overlap = k & bullet_keys
 
             next if key_objects_overlap.empty?
 
+            bullet_keys = bullet_keys - k
             if key_objects_overlap == k
-              to_add = [k, associations]
-              break
+              to_add << [k, associations]
             else
               to_merge << [key_objects_overlap, ( eager_loadings[k].dup  << associations )]
 
-              keys_without_objects = k - bullet_keys
+              keys_without_objects = k - key_objects_overlap
               to_merge << [keys_without_objects, eager_loadings[k]]
               to_delete << k
-              bullet_keys = bullet_keys - k
             end
           end
 
-          eager_loadings.add(*to_add) if to_add
+          to_add.each { |k, val| eager_loadings.add k, val }
           to_merge.each { |k, val| eager_loadings.merge k, val }
           to_delete.each { |k| eager_loadings.delete k }
 

--- a/spec/bullet/detector/unused_eager_loading_spec.rb
+++ b/spec/bullet/detector/unused_eager_loading_spec.rb
@@ -5,7 +5,8 @@ module Bullet
     describe UnusedEagerLoading do
       before(:all) do
         @post = Post.first
-        @post2 = Post.last
+        @post2 = Post.second
+        @post3 = Post.last
       end
 
       context ".call_associations" do
@@ -72,7 +73,18 @@ module Bullet
           UnusedEagerLoading.add_eager_loadings([@post, @post2], :association2)
           expect(UnusedEagerLoading.send(:eager_loadings)).to be_include([@post.bullet_key], :association1)
           expect(UnusedEagerLoading.send(:eager_loadings)).to be_include([@post.bullet_key], :association2)
-          expect(UnusedEagerLoading.send(:eager_loadings)).to be_include([@post.bullet_key, @post2.bullet_key], :association2)
+          expect(UnusedEagerLoading.send(:eager_loadings)).to be_include([@post2.bullet_key], :association2)
+        end
+
+        it "should vmerge objects recursively, associations pair for existing eager_loadings" do
+          UnusedEagerLoading.add_eager_loadings([@post, @post2], :association1)
+          UnusedEagerLoading.add_eager_loadings([@post, @post3], :association1)
+          UnusedEagerLoading.add_eager_loadings([@post, @post3], :association2)
+          expect(UnusedEagerLoading.send(:eager_loadings)).to be_include([@post.bullet_key], :association1)
+          expect(UnusedEagerLoading.send(:eager_loadings)).to be_include([@post.bullet_key], :association2)
+          expect(UnusedEagerLoading.send(:eager_loadings)).to be_include([@post2.bullet_key], :association1)
+          expect(UnusedEagerLoading.send(:eager_loadings)).to be_include([@post3.bullet_key], :association1)
+          expect(UnusedEagerLoading.send(:eager_loadings)).to be_include([@post3.bullet_key], :association2)
         end
 
         it "should delete objects, associations pair for existing eager_loadings" do


### PR DESCRIPTION
example:
```ruby
Post.includes(:comments).each { |p| p.comments }  # [post1, post2]
Post.includes(:comments, :tags).each { |p| p.comments; p.tags } # [post1, post3]
```
both two query results include same object _post1_, incorrectly show the warning.