### PR TITLE
Fix whitelisting bug for classes ending w/ S

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -82,8 +82,8 @@ module Bullet
 
     def add_whitelist(options)
       reset_whitelist
-      @whitelist[options[:type]][options[:class_name].classify] ||= []
-      @whitelist[options[:type]][options[:class_name].classify] << options[:association].to_sym
+      @whitelist[options[:type]][options[:class_name]] ||= []
+      @whitelist[options[:type]][options[:class_name]] << options[:association].to_sym
     end
 
     def get_whitelist_associations(type, class_name)

--- a/spec/bullet_spec.rb
+++ b/spec/bullet_spec.rb
@@ -85,4 +85,13 @@ describe Bullet, focused: true do
       end
     end
   end
+
+  describe '#add_whitelist' do
+    context 'for ‘special’ class names' do
+      it 'is added to the whitelist successfully' do
+        Bullet.add_whitelist(:type => :n_plus_one_query, :class_name => 'Klass', :association => :department)
+        expect(Bullet.get_whitelist_associations(:n_plus_one_query, 'Klass')).to include :department
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What?
1. Create a class named Loss, which belongs to a User
2. Add a N+1 query that reads losses.user
3. Whitelist the association

Expected: The query is not flagged
Actual: The query is flagged 
```
N+1 Query detected
  Loss => [:user]
  Add to your finder: :includes => [:user]
```

# How?
N+1 query whitelists are not respected for classes like Loss, Status because calling `classify` alters the key names to Los, Statu

# Solution
Do not call classify on the klass names.