### PR TITLE
Add response handling for non-Rails Rack responses

### DIFF
--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -67,7 +67,7 @@ module Bullet
     end
 
     def response_body(response)
-      if rails?
+      if response.respond_to?(:body)
         Array === response.body ? response.body.first : response.body
       else
         response.first

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -93,5 +93,36 @@ module Bullet
         end
       end
     end
+
+    describe "#response_body" do
+      let(:response) { double }
+      let(:body_string) { "<html><body>My Body</body></html>" }
+
+      context "when `response` responds to `body`" do
+        before { allow(response).to receive(:body).and_return(body) }
+
+        context "when `body` returns an Array" do
+          let(:body) { [body_string, 'random string'] }
+          it "should return the plain body string" do
+            expect(middleware.response_body(response)).to eq body_string
+          end
+        end
+
+        context "when `body` does not return an Array" do
+          let(:body) { body_string }
+          it "should return the plain body string" do
+            expect(middleware.response_body(response)).to eq body_string
+          end
+        end
+      end
+
+      context "when `response` does not respond to `body`" do
+        before { allow(response).to receive(:first).and_return(body_string) }
+
+        it "should return the plain body string" do
+          expect(middleware.response_body(response)).to eq body_string
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Issue:
When using a setup like e.g. Grape mounted on Rack, the response body will still be nested under `response.body`. Yet, the Gem will try to access `.first` on the response object, which leads to method not found exception.

## Fix:
Instead of checking if the Gem is running in a Rails environment (via `rails?`) we can check if a response has a `body` set, and if so, return this. If not, the fallback will remain to be the `response.first` call.