### PR TITLE
Disable Travis builds for failing configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ services:
 matrix:
   exclude:
     - rvm: 1.9.3
+      gemfile: Gemfile.rails-4.0
+    - rvm: 1.9.3
+      gemfile: Gemfile.rails-4.1
+    - rvm: 1.9.3
+      gemfile: Gemfile.rails-4.2
+    - rvm: 1.9.3
       gemfile: Gemfile.rails-5.0
     - rvm: 1.9.3
       gemfile: Gemfile.mongoid-2.4


### PR DESCRIPTION
The Ruby 1.9.3 build consistently fails for Rails 4.x versions.
This is due to a dependency on the [`mime-types-data` gem which is not compatible with Ruby < 2.x](https://rubygems.org/gems/mime-types-data).

These are two failing Travis  builds for reference:
 - https://travis-ci.org/flyerhzm/bullet/builds/118186461
 - https://travis-ci.org/flyerhzm/bullet/builds/127187543

Therefore, exclude the following configurations:
 - Ruby 1.9.3 and Rails 4.0
 - Ruby 1.9.3 and Rails 4.1
 - Ruby 1.9.3 and Rails 4.2
