### PR TITLE
[WIP] .profile respects the return value of the given block

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -190,17 +190,22 @@ module Bullet
     end
 
     def profile
+      return_value = nil
       if Bullet.enable?
         begin
           Bullet.start_request
 
-          yield
+          return_value = yield
 
           Bullet.perform_out_of_channel_notifications if Bullet.notification?
         ensure
           Bullet.end_request
         end
+      else
+        return_value = yield
       end
+
+      return_value
     end
 
     private


### PR DESCRIPTION
Given the Luke class
```lang=ruby
class Luke
  def father
    Bullet.profile do
      :darth_fader
    end
  end
end
```

`Bullet.profile` now returns the return value of the block given. In this example the `father` will behave like:
```lang=ruby
> Luke.new.father
=> :darth_fader
````

It also returns the value regardless the enabled or disabled state of Bullet
```lang=ruby
> Bullet.enable = true
=> true
> Luke.new.father
=> :darth_fader
> Bullet.enable = false
> Luke.new.father
=> :darth_fader
````