### PR TITLE
Build request uri when env['REQUEST_URI'] does not exist

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -166,8 +166,9 @@ module Bullet
     end
 
     def perform_out_of_channel_notifications(env = {})
+      request_uri = env['REQUEST_URI'] || build_request_uri(env)
       for_each_active_notifier_with_notification do |notification|
-        notification.url = env['REQUEST_URI'] || build_request_uri(env)
+        notification.url = request_uri
         notification.notify_out_of_channel
       end
     end

--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -167,7 +167,7 @@ module Bullet
 
     def perform_out_of_channel_notifications(env = {})
       for_each_active_notifier_with_notification do |notification|
-        notification.url = env['REQUEST_URI']
+        notification.url = env['REQUEST_URI'] || build_request_uri(env)
         notification.notify_out_of_channel
       end
     end
@@ -215,6 +215,14 @@ module Bullet
             notification.notifier = notifier
             yield notification
           end
+        end
+      end
+
+      def build_request_uri(env)
+        if env['QUERY_STRING'].present?
+          "#{env['PATH_INFO']}?#{env['QUERY_STRING']}"
+        else
+          env['PATH_INFO']
         end
       end
   end

--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -20,7 +20,6 @@ module Bullet
           append_to_html_body(response_body, Bullet.gather_inline_notifications)
           headers['Content-Length'] = response_body.bytesize.to_s
         end
-        env['REQUEST_URI'] ||= build_request_uri(env)
         Bullet.perform_out_of_channel_notifications(env)
       end
       [status, headers, response_body ? [response_body] : response]
@@ -72,14 +71,6 @@ module Bullet
         Array === response.body ? response.body.first : response.body
       else
         response.first
-      end
-    end
-
-    def build_request_uri(env)
-      if env['QUERY_STRING'].present?
-        "#{env['PATH_INFO']}?#{env['QUERY_STRING']}"
-      else
-        env['PATH_INFO']
       end
     end
 

--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -20,6 +20,7 @@ module Bullet
           append_to_html_body(response_body, Bullet.gather_inline_notifications)
           headers['Content-Length'] = response_body.bytesize.to_s
         end
+        env['REQUEST_URI'] ||= build_request_uri(env)
         Bullet.perform_out_of_channel_notifications(env)
       end
       [status, headers, response_body ? [response_body] : response]
@@ -71,6 +72,14 @@ module Bullet
         Array === response.body ? response.body.first : response.body
       else
         response.first
+      end
+    end
+
+    def build_request_uri(env)
+      if env['QUERY_STRING'].present?
+        "#{env['PATH_INFO']}?#{env['QUERY_STRING']}"
+      else
+        env['PATH_INFO']
       end
     end
 

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -124,25 +124,5 @@ module Bullet
         end
       end
     end
-
-    describe "#build_request_uri" do
-      let(:env) { { 'PATH_INFO' => '/path' } }
-
-      context "when QUERY_STRING exists" do
-        before { env['QUERY_STRING'] = 'foo=bar' }
-
-        it "should return PATH_INFO with QUERY_STRING" do
-          expect(middleware.build_request_uri(env)).to eq '/path?foo=bar'
-        end
-      end
-
-      context "when QUERY_STRING does not exists" do
-        before { env['QUERY_STRING'] = '' }
-
-        it "should return PATH_INFO" do
-          expect(middleware.build_request_uri(env)).to eq '/path'
-        end
-      end
-    end
   end
 end

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -124,5 +124,25 @@ module Bullet
         end
       end
     end
+
+    describe "#build_request_uri" do
+      let(:env) { { 'PATH_INFO' => '/path' } }
+
+      context "when QUERY_STRING exists" do
+        before { env['QUERY_STRING'] = 'foo=bar' }
+
+        it "should return PATH_INFO with QUERY_STRING" do
+          expect(middleware.build_request_uri(env)).to eq '/path?foo=bar'
+        end
+      end
+
+      context "when QUERY_STRING does not exists" do
+        before { env['QUERY_STRING'] = '' }
+
+        it "should return PATH_INFO" do
+          expect(middleware.build_request_uri(env)).to eq '/path'
+        end
+      end
+    end
   end
 end

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -60,7 +60,7 @@ module Bullet
         it "should return original response body" do
           expected_response = Support::ResponseDouble.new "Actual body"
           app.response = expected_response
-          _, _, response = middleware.call([])
+          _, _, response = middleware.call({})
           expect(response).to eq(expected_response)
         end
 
@@ -68,7 +68,7 @@ module Bullet
           expect(Bullet).to receive(:notification?).and_return(true)
           expect(Bullet).to receive(:gather_inline_notifications).and_return("<bullet></bullet>")
           expect(Bullet).to receive(:perform_out_of_channel_notifications)
-          status, headers, response = middleware.call([200, {"Content-Type" => "text/html"}])
+          status, headers, response = middleware.call({"Content-Type" => "text/html"})
           expect(headers["Content-Length"]).to eq("56")
           expect(response).to eq(["<html><head></head><body><bullet></bullet></body></html>"])
         end
@@ -79,7 +79,7 @@ module Bullet
           app.response = response
           expect(Bullet).to receive(:notification?).and_return(true)
           expect(Bullet).to receive(:gather_inline_notifications).and_return("<bullet></bullet>")
-          status, headers, response = middleware.call([200, {"Content-Type" => "text/html"}])
+          status, headers, response = middleware.call({"Content-Type" => "text/html"})
           expect(headers["Content-Length"]).to eq("58")
         end
       end
@@ -89,7 +89,7 @@ module Bullet
 
         it "should not call Bullet.start_request" do
           expect(Bullet).not_to receive(:start_request)
-          middleware.call([])
+          middleware.call({})
         end
       end
     end


### PR DESCRIPTION
Bullet `notification.url` will sometimes be empty. Because a notification url is a env['REQUEST_URI'] and it does not necessarily exist.

In general, REQUEST_URI is provided by a Web server like WEBrick, Unicorn, puma, ...

But in the test code,

RSpec's Request spec:
  
  * Rails integration test set a REQUEST_URI
    * ref: https://github.com/rails/rails/blob/173bf3506d99c0767a41d30fbe4d306201369194/actionpack/lib/action_dispatch/testing/integration.rb#L354
  
RSpec's Feature spec:
  
  * RackTest, Capybara's default driver interacts directory with Rack interface
  * [Rack envirionment](http://www.rubydoc.info/github/rack/rack/file/SPEC) does not include REQUEST_URI

In this PR, build dummy REQUEST_URI using PATH_INFO and QUERY_STRING when it is empty.

