### PR TITLE
Add Bullet.assign_attributes method

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -208,6 +208,12 @@ module Bullet
       return_value
     end
 
+    def assign_attributes(attributes = {})
+      attributes.each_pair do |key, value|
+        public_send("#{key}=", value)
+      end
+    end
+
     private
       def for_each_active_notifier_with_notification
         UniformNotifier.active_notifiers.each do |notifier|

--- a/spec/bullet_spec.rb
+++ b/spec/bullet_spec.rb
@@ -94,4 +94,13 @@ describe Bullet, focused: true do
       end
     end
   end
+
+  describe '.assign_attributes' do
+    it 'assigns attributes' do
+      Bullet.assign_attributes(enable: true, counter_cache_enable: false)
+
+      expect(Bullet.enable?).to be true
+      expect(Bullet.counter_cache_enable?).to be false
+    end
+  end
 end


### PR DESCRIPTION
What I suggest here is adding mass assignment to `Bullet`. There are a lot of options which can be put into `config/bullet.yml` file:

```
development:
  enable: true
  alert: true
  bullet_logger: true
  rails_logger: true
  add_footer: true

test:
  enable: true
  bullet_logger: true
  raise: true
```

And then add to `development.rb` 

```
config.after_initialize do
  Bullet.assign_attributes(config_for(:bullet))
end
```

(using [Rails config_for](http://apidock.com/rails/v4.2.1/Rails/Application/config_for))
