### PR TITLE
Stacktrace filter module

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -4,6 +4,7 @@ require 'uniform_notifier'
 require 'bullet/ext/object'
 require 'bullet/ext/string'
 require 'bullet/dependency'
+require 'bullet/stack_trace_filter'
 
 module Bullet
   extend Dependency

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -91,15 +91,15 @@ module Bullet
           def caller_in_project
             app_root = rails? ? Rails.root.to_s : Dir.pwd
             vendor_root = app_root + "/vendor"
-            caller.select do |c|
-              c.include?(app_root) && !c.include?(vendor_root) ||
-              Bullet.stacktrace_includes.any? { |include| c.include?(include) }
+            caller.select do |included_path|
+              included_path.include?(app_root) && !included_path.include?(vendor_root) ||
+              Bullet.stacktrace_includes.any? { |regex| included_path =~ regex }
             end
           end
 
           def excluded_stacktrace_path?
             Bullet.stacktrace_excludes.any? do |excluded_path|
-              caller_in_project.any? { |c| c.include?(excluded_path) }
+              caller_in_project.any? { |regex| excluded_path =~ regex }
             end
           end
       end

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -2,6 +2,7 @@ module Bullet
   module Detector
     class NPlusOneQuery < Association
       extend Dependency
+      extend StackTraceFilter
 
       class <<self
         # executed when object.assocations is called.
@@ -85,21 +86,6 @@ module Bullet
             if notify_associations.present?
               notice = Bullet::Notification::NPlusOneQuery.new(callers, klazz, notify_associations)
               Bullet.notification_collector.add(notice)
-            end
-          end
-
-          def caller_in_project
-            app_root = rails? ? Rails.root.to_s : Dir.pwd
-            vendor_root = app_root + "/vendor"
-            caller.select do |included_path|
-              included_path.include?(app_root) && !included_path.include?(vendor_root) ||
-              Bullet.stacktrace_includes.any? { |regex| included_path =~ regex }
-            end
-          end
-
-          def excluded_stacktrace_path?
-            Bullet.stacktrace_excludes.any? do |excluded_path|
-              caller_in_project.any? { |regex| excluded_path =~ regex }
             end
           end
       end

--- a/lib/bullet/detector/unused_eager_loading.rb
+++ b/lib/bullet/detector/unused_eager_loading.rb
@@ -2,6 +2,7 @@ module Bullet
   module Detector
     class UnusedEagerLoading < Association
       extend Dependency
+      extend StackTraceFilter
 
       class <<self
         # check if there are unused preload associations.
@@ -77,21 +78,6 @@ module Bullet
           def diff_object_associations(bullet_key, associations)
             potential_associations = associations - call_associations(bullet_key, associations)
             potential_associations.reject { |a| a.is_a?(Hash) }
-          end
-
-          def caller_in_project
-            app_root = rails? ? Rails.root.to_s : Dir.pwd
-            vendor_root = app_root + "/vendor"
-            caller.select do |included_path|
-              included_path.include?(app_root) && !included_path.include?(vendor_root) ||
-              Bullet.stacktrace_includes.any? { |regex| included_path =~ regex }
-            end
-          end
-
-          def excluded_stacktrace_path?
-            Bullet.stacktrace_excludes.any? do |excluded_path|
-              caller_in_project.any? { |regex| excluded_path =~ regex }
-            end
           end
       end
     end

--- a/lib/bullet/notification/unused_eager_loading.rb
+++ b/lib/bullet/notification/unused_eager_loading.rb
@@ -1,6 +1,18 @@
 module Bullet
   module Notification
     class UnusedEagerLoading < Base
+      def initialize(callers, base_class, associations, path = nil)
+        super(base_class, associations, path)
+
+        @callers = callers
+      end
+
+      def notification_data
+        super.merge(
+          :backtrace => @callers
+        )
+      end
+
       def body
         "#{klazz_associations_str}\n  Remove from your finder: #{associations_str}"
       end

--- a/lib/bullet/stack_trace_filter.rb
+++ b/lib/bullet/stack_trace_filter.rb
@@ -1,0 +1,34 @@
+module Bullet
+  module StackTraceFilter
+    VENDOR_PATH = "/vendor"
+
+    def caller_in_project
+      app_root = rails? ? Rails.root.to_s : Dir.pwd
+      vendor_root = app_root + VENDOR_PATH
+      caller.select do |caller_path|
+        caller_path.include?(app_root) && !caller_path.include?(vendor_root) ||
+          Bullet.stacktrace_includes.any? do |include_pattern|
+          case include_pattern
+          when String
+            caller_path.include?(include_pattern)
+          when Regexp
+            caller_path =~ include_pattern
+          end
+        end
+      end
+    end
+
+    def excluded_stacktrace_path?
+      Bullet.stacktrace_excludes.any? do |exclude_pattern|
+        caller_in_project.any? do |caller_path|
+          case exclude_pattern
+          when String
+            caller_path.include?(exclude_pattern)
+          when Regexp
+            caller_path =~ exclude_pattern
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/bullet/detector/n_plus_one_query_spec.rb
+++ b/spec/bullet/detector/n_plus_one_query_spec.rb
@@ -87,7 +87,7 @@ module Bullet
         end
 
         context "stacktrace_excludes" do
-          before { Bullet.stacktrace_excludes = [ 'def' ] }
+          before { Bullet.stacktrace_excludes = [ /def/ ] }
           after { Bullet.stacktrace_excludes = nil }
 
           it "should not create notification when stacktrace contains paths that are in the exclude list" do
@@ -114,7 +114,7 @@ module Bullet
         end
 
         context "stacktrace_includes" do
-          before { Bullet.stacktrace_includes = [ 'def' ] }
+          before { Bullet.stacktrace_includes = [ /def/ ] }
           after { Bullet.stacktrace_includes = nil }
 
           it "should include paths that are in the stacktrace_include list" do

--- a/spec/bullet/detector/n_plus_one_query_spec.rb
+++ b/spec/bullet/detector/n_plus_one_query_spec.rb
@@ -114,17 +114,17 @@ module Bullet
         end
 
         context "stacktrace_includes" do
-          before { Bullet.stacktrace_includes = [ /def/ ] }
+          before { Bullet.stacktrace_includes = [ 'def', /xyz/ ] }
           after { Bullet.stacktrace_includes = nil }
 
           it "should include paths that are in the stacktrace_include list" do
             in_project = File.join(Dir.pwd, 'abc', 'abc.rb')
-            included_gem = '/def/def.rb'
+            included_gems = ['/def/def.rb', 'xyz/xyz.rb']
             excluded_gem = '/ghi/ghi.rb'
 
-            expect(NPlusOneQuery).to receive(:caller).and_return([in_project, included_gem, excluded_gem])
+            expect(NPlusOneQuery).to receive(:caller).and_return([in_project, *included_gems, excluded_gem])
             expect(NPlusOneQuery).to receive(:conditions_met?).with(@post, :association).and_return(true)
-            expect(NPlusOneQuery).to receive(:create_notification).with([in_project, included_gem], "Post", :association)
+            expect(NPlusOneQuery).to receive(:create_notification).with([in_project, *included_gems], "Post", :association)
             NPlusOneQuery.call_association(@post, :association)
           end
         end

--- a/spec/bullet/detector/unused_eager_loading_spec.rb
+++ b/spec/bullet/detector/unused_eager_loading_spec.rb
@@ -39,9 +39,11 @@ module Bullet
       end
 
       context ".check_unused_preload_associations" do
+        let(:paths) { ["/dir1", "/dir1/subdir"] }
         it "should create notification if object_association_diff is not empty" do
           UnusedEagerLoading.add_object_associations(@post, :association)
-          expect(UnusedEagerLoading).to receive(:create_notification).with("Post", [:association])
+          allow(UnusedEagerLoading).to receive(:caller_in_project).and_return(paths)
+          expect(UnusedEagerLoading).to receive(:create_notification).with(paths, "Post", [:association])
           UnusedEagerLoading.check_unused_preload_associations
         end
 

--- a/spec/bullet/notification/unused_eager_loading_spec.rb
+++ b/spec/bullet/notification/unused_eager_loading_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Bullet
   module Notification
     describe UnusedEagerLoading do
-      subject { UnusedEagerLoading.new(Post, [:comments, :votes], "path") }
+      subject { UnusedEagerLoading.new([""], Post, [:comments, :votes], "path") }
 
       it { expect(subject.body).to eq("  Post => [:comments, :votes]\n  Remove from your finder: :includes => [:comments, :votes]") }
       it { expect(subject.title).to eq("Unused Eager Loading in path") }


### PR DESCRIPTION
- Extracts stack trace filtering into module.
- Adds stack trace filtering to unused eager loading detector.
- Adds ability to filter by either caller path includes substring or caller path matches regex.
