### PR TITLE
Add close button to footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The code above will enable all seven of the Bullet notification systems:
 * `Bullet.growl`: pop up Growl warnings if your system has Growl installed. Requires a little bit of configuration
 * `Bullet.xmpp`: send XMPP/Jabber notifications to the receiver indicated. Note that the code will currently not handle the adding of contacts, so you will need to make both accounts indicated know each other manually before you will receive any notifications. If you restart the development server frequently, the 'coming online' sound for the Bullet account may start to annoy - in this case set :show_online_status to false; you will still get notifications, but the Bullet account won't announce it's online status anymore.
 * `Bullet.raise`: raise errors, useful for making your specs fail unless they have optimized queries
-* `Bullet.add_footer`: adds the details in the bottom left corner of the page
+* `Bullet.add_footer`: adds the details in the bottom left corner of the page. Double click the footer or use close button to hide footer.
 * `Bullet.stacktrace_includes`: include paths with any of these substrings in the stack trace, even if they are not in your main app
 * `Bullet.stacktrace_excludes`: ignore paths with any of these substrings in the stack trace, even if they are not in your main app.
 * `Bullet.slack`: add notifications to slack

--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -51,7 +51,7 @@ module Bullet
     end
 
     def footer_note
-      "<div #{footer_div_attributes}>" + Bullet.footer_info.uniq.join("<br>") + "</div>"
+      "<div #{footer_div_attributes}>" + footer_close_button + Bullet.footer_info.uniq.join("<br>") + "</div>"
     end
 
     def file?(headers)
@@ -75,6 +75,7 @@ module Bullet
     end
 
     private
+
     def footer_div_attributes
 <<EOF
 data-is-bullet-footer ondblclick="this.parentNode.removeChild(this);" style="position: fixed; bottom: 0pt; left: 0pt; cursor: pointer; border-style: solid; border-color: rgb(153, 153, 153);
@@ -83,6 +84,10 @@ data-is-bullet-footer ondblclick="this.parentNode.removeChild(this);" style="pos
  padding: 3px 5px; border-radius: 0pt 10pt 0pt 0px; background: none repeat scroll 0% 0% rgba(200, 200, 200, 0.8);
  color: rgb(119, 119, 119); font-size: 16px; font-family: 'Arial', sans-serif; z-index:9999;"
 EOF
+    end
+
+    def footer_close_button
+      "<span onclick='this.parentNode.remove()' style='position:absolute; right: 10px; top: 0px; font-weight: bold; color: #333;'>&times;</span>"
     end
   end
 end


### PR DESCRIPTION
I always end up opening developer tools and removing the footer so I can click on some button. So I added a close button to the top right of the footer to make life easier. I didn't realize that double clicking the footer would also close this until I was editing the code for this.