### PR TITLE
Avoid double backtrace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ benchmark_profile*
 coverage/
 .coveralls.yml
 Gemfile*.lock
+.idea/

--- a/lib/bullet/notification/n_plus_one_query.rb
+++ b/lib/bullet/notification/n_plus_one_query.rb
@@ -12,18 +12,18 @@ module Bullet
       end
 
       def title
-        "N+1 Query #{@path ? "in #{@path}" : 'detected'}"
+        "USE eager loading #{@path ? "in #{@path}" : 'detected'}"
       end
 
       def notification_data
         super.merge(
-          :backtrace => @callers
+          :backtrace => []
         )
       end
 
       protected
         def call_stack_messages
-          (['N+1 Query method call stack'] + @callers).join( "\n  " )
+          (['Call stack'] + @callers).join( "\n  " )
         end
     end
   end

--- a/lib/bullet/notification/unused_eager_loading.rb
+++ b/lib/bullet/notification/unused_eager_loading.rb
@@ -7,19 +7,24 @@ module Bullet
         @callers = callers
       end
 
-      def notification_data
-        super.merge(
-          :backtrace => @callers
-        )
-      end
-
       def body
         "#{klazz_associations_str}\n  Remove from your finder: #{associations_str}"
       end
 
       def title
-        "Unused Eager Loading #{@path ? "in #{@path}" : 'detected'}"
+        "AVOID eager loading #{@path ? "in #{@path}" : 'detected'}"
       end
+
+      def notification_data
+        super.merge(
+            :backtrace => []
+        )
+      end
+
+      protected
+        def call_stack_messages
+          (['Call stack'] + @callers).join( "\n  " )
+        end
     end
   end
 end

--- a/spec/bullet/notification/n_plus_one_query_spec.rb
+++ b/spec/bullet/notification/n_plus_one_query_spec.rb
@@ -5,10 +5,10 @@ module Bullet
     describe NPlusOneQuery do
       subject { NPlusOneQuery.new([["caller1", "caller2"]], Post, [:comments, :votes], "path") }
 
-      it { expect(subject.body_with_caller).to eq("  Post => [:comments, :votes]\n  Add to your finder: :includes => [:comments, :votes]\nN+1 Query method call stack\n  caller1\n  caller2\n") }
-      it { expect([subject.body_with_caller, subject.body_with_caller]).to eq([ "  Post => [:comments, :votes]\n  Add to your finder: :includes => [:comments, :votes]\nN+1 Query method call stack\n  caller1\n  caller2\n", "  Post => [:comments, :votes]\n  Add to your finder: :includes => [:comments, :votes]\nN+1 Query method call stack\n  caller1\n  caller2\n" ]) }
+      it { expect(subject.body_with_caller).to eq("  Post => [:comments, :votes]\n  Add to your finder: :includes => [:comments, :votes]\nCall stack\n  caller1\n  caller2\n") }
+      it { expect([subject.body_with_caller, subject.body_with_caller]).to eq([ "  Post => [:comments, :votes]\n  Add to your finder: :includes => [:comments, :votes]\nCall stack\n  caller1\n  caller2\n", "  Post => [:comments, :votes]\n  Add to your finder: :includes => [:comments, :votes]\nCall stack\n  caller1\n  caller2\n" ]) }
       it { expect(subject.body).to eq("  Post => [:comments, :votes]\n  Add to your finder: :includes => [:comments, :votes]") }
-      it { expect(subject.title).to eq("N+1 Query in path") }
+      it { expect(subject.title).to eq("USE eager loading in path") }
     end
   end
 end

--- a/spec/bullet/notification/unused_eager_loading_spec.rb
+++ b/spec/bullet/notification/unused_eager_loading_spec.rb
@@ -6,7 +6,7 @@ module Bullet
       subject { UnusedEagerLoading.new([""], Post, [:comments, :votes], "path") }
 
       it { expect(subject.body).to eq("  Post => [:comments, :votes]\n  Remove from your finder: :includes => [:comments, :votes]") }
-      it { expect(subject.title).to eq("Unused Eager Loading in path") }
+      it { expect(subject.title).to eq("AVOID eager loading in path") }
     end
   end
 end


### PR DESCRIPTION
I was getting double backtraces when N+1 Queries were detected. This fixes that.

Additionally, I changed `N+1 Query` to `USE eager loading` and `Unused Eager Loading` to `AVOID eager loading` for symmetry and for making the suggestion more relevant.