### PR TITLE
Fix inverse_of for rails 5

### DIFF
--- a/lib/bullet/active_record5.rb
+++ b/lib/bullet/active_record5.rb
@@ -21,8 +21,8 @@ module Bullet
       ::ActiveRecord::Base.class_eval do
         class <<self
           alias_method :origin_find_by_sql, :find_by_sql
-          def find_by_sql(sql, binds = [], preparable: nil)
-            result = origin_find_by_sql(sql, binds, preparable: nil)
+          def find_by_sql(sql, binds = [], preparable: nil, &block)
+            result = origin_find_by_sql(sql, binds, preparable: nil, &block)
             if Bullet.start?
               if result.is_a? Array
                 if result.size > 1


### PR DESCRIPTION
Hi!

I'm not sure if this related to rails < 5.0.1, I haven't check their source. But this change will not break anything.

Here https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/relation.rb#L702 `find_by_sql` is called with block from https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/association_relation.rb#L33 which sets inverse values. As in patched versions block is not passed, inverse values are not set. This results in false warnings for code like this one `order.items.map(&:order)` (with `inverse_of`).

I'm not familiar with bullet's test, so haven't added one for this.

WDYT about change args in all methods to `*args, &block` and to call original methods with this args. It would without change if they would add new kwargs or change default values in new versions of rails?