### PR TITLE
Re-order notifier explanations to match configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,23 +70,24 @@ end
 
 The notifier of Bullet is a wrap of [uniform_notifier](https://github.com/flyerhzm/uniform_notifier)
 
-The code above will enable all seven of the Bullet notification systems:
+The code above will enable all of the Bullet notification systems:
 * `Bullet.enable`: enable Bullet gem, otherwise do nothing
 * `Bullet.alert`: pop up a JavaScript alert in the browser
 * `Bullet.bullet_logger`: log to the Bullet log file (Rails.root/log/bullet.log)
+* `Bullet.console`: log warnings to your browser's console.log (Safari/Webkit browsers or Firefox w/Firebug installed)
+* `Bullet.growl`: pop up Growl warnings if your system has Growl installed. Requires a little bit of configuration
+* `Bullet.xmpp`: send XMPP/Jabber notifications to the receiver indicated. Note that the code will currently not handle the adding of contacts, so you will need to make both accounts indicated know each other manually before you will receive any notifications. If you restart the development server frequently, the 'coming online' sound for the Bullet account may start to annoy - in this case set :show_online_status to false; you will still get notifications, but the Bullet account won't announce it's online status anymore.
 * `Bullet.rails_logger`: add warnings directly to the Rails log
 * `Bullet.honeybadger`: add notifications to Honeybadger
 * `Bullet.bugsnag`: add notifications to bugsnag
 * `Bullet.airbrake`: add notifications to airbrake
 * `Bullet.rollbar`: add notifications to rollbar
-* `Bullet.console`: log warnings to your browser's console.log (Safari/Webkit browsers or Firefox w/Firebug installed)
-* `Bullet.growl`: pop up Growl warnings if your system has Growl installed. Requires a little bit of configuration
-* `Bullet.xmpp`: send XMPP/Jabber notifications to the receiver indicated. Note that the code will currently not handle the adding of contacts, so you will need to make both accounts indicated know each other manually before you will receive any notifications. If you restart the development server frequently, the 'coming online' sound for the Bullet account may start to annoy - in this case set :show_online_status to false; you will still get notifications, but the Bullet account won't announce it's online status anymore.
-* `Bullet.raise`: raise errors, useful for making your specs fail unless they have optimized queries
 * `Bullet.add_footer`: adds the details in the bottom left corner of the page. Double click the footer or use close button to hide footer.
 * `Bullet.stacktrace_includes`: include paths with any of these substrings in the stack trace, even if they are not in your main app
 * `Bullet.stacktrace_excludes`: ignore paths with any of these substrings in the stack trace, even if they are not in your main app.
 * `Bullet.slack`: add notifications to slack
+* `Bullet.raise`: raise errors, useful for making your specs fail unless they have optimized queries
+
 
 Bullet also allows you to disable any of its detectors.
 


### PR DESCRIPTION
I also removed the word 'seven' since there are more than seven notification systems now.

I noticed that `raise` isn't mention in the configuration code, not sure if this is intentional or not.