### PR TITLE
Use secure protocol when running `bundle install`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,13 @@
 source 'https://rubygems.org'
 
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
+  "https://github.com/#{repo_name}.git"
+end
+
 gemspec
 
-gem 'rails', github: 'rails/rails'
+gem 'rails', github: 'rails'
 gem 'sqlite3', platforms: [:ruby]
 gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
 gem 'activerecord-import'


### PR DESCRIPTION
This PR suppresses the following warnings.

```sh
% bundle install
The git source `git://github.com/rails/rails.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
```

Refer: https://github.com/bundler/bundler/pull/4127