### PR TITLE
Testing with newer Rails 5 gems

### DIFF
--- a/Gemfile.rails-5.0
+++ b/Gemfile.rails-5.0
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rails', '5.0.0'
+gem 'rails', '~> 5.0.0'
 gem 'sqlite3'
 gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
 gem 'activerecord-import'

--- a/Gemfile.rails-5.1
+++ b/Gemfile.rails-5.1
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rails', '5.1.0.beta.1'
+gem 'rails', '~> 5.1.0'
 gem 'sqlite3'
 gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
 gem 'activerecord-import'


### PR DESCRIPTION
Here's a trivial patch that lets the CI run on newer stable versions of Rails 5.0.x and 5.1.x.