### PR TITLE
Freeze strings

### DIFF
--- a/lib/bullet/detector/association.rb
+++ b/lib/bullet/detector/association.rb
@@ -7,7 +7,7 @@ module Bullet
           return if !Bullet.n_plus_one_query_enable? && !Bullet.unused_eager_loading_enable?
           return unless object.primary_key_value
 
-          Bullet.debug("Detector::Association#add_object_associations", "object: #{object.bullet_key}, associations: #{associations}")
+          Bullet.debug("Detector::Association#add_object_associations".freeze, "object: #{object.bullet_key}, associations: #{associations}")
           object_associations.add(object.bullet_key, associations)
         end
 
@@ -16,7 +16,7 @@ module Bullet
           return if !Bullet.n_plus_one_query_enable? && !Bullet.unused_eager_loading_enable?
           return unless object.primary_key_value
 
-          Bullet.debug("Detector::Association#add_call_object_associations", "object: #{object.bullet_key}, associations: #{associations}")
+          Bullet.debug("Detector::Association#add_call_object_associations".freeze, "object: #{object.bullet_key}, associations: #{associations}")
           call_object_associations.add(object.bullet_key, associations)
         end
 

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -16,7 +16,7 @@ module Bullet
           return if inversed_objects.include?(object.bullet_key, associations)
           add_call_object_associations(object, associations)
 
-          Bullet.debug("Detector::NPlusOneQuery#call_association", "object: #{object.bullet_key}, associations: #{associations}")
+          Bullet.debug("Detector::NPlusOneQuery#call_association".freeze, "object: #{object.bullet_key}, associations: #{associations}")
           if !excluded_stacktrace_path? && conditions_met?(object, associations)
             Bullet.debug("detect n + 1 query", "object: #{object.bullet_key}, associations: #{associations}")
             create_notification caller_in_project, object.class.to_s, associations
@@ -29,7 +29,7 @@ module Bullet
           objects = Array(object_or_objects)
           return if objects.map(&:primary_key_value).compact.empty?
 
-          Bullet.debug("Detector::NPlusOneQuery#add_possible_objects", "objects: #{objects.map(&:bullet_key).join(', '.freeze)}")
+          Bullet.debug("Detector::NPlusOneQuery#add_possible_objects".freeze, "objects: #{objects.map(&:bullet_key).join(', '.freeze)}")
           objects.each { |object| possible_objects.add object.bullet_key }
         end
 
@@ -38,7 +38,7 @@ module Bullet
           return unless Bullet.n_plus_one_query_enable?
           return unless object.primary_key_value
 
-          Bullet.debug("Detector::NPlusOneQuery#add_impossible_object", "object: #{object.bullet_key}")
+          Bullet.debug("Detector::NPlusOneQuery#add_impossible_object".freeze, "object: #{object.bullet_key}")
           impossible_objects.add object.bullet_key
         end
 
@@ -47,7 +47,7 @@ module Bullet
           return unless Bullet.n_plus_one_query_enable?
           return unless object.primary_key_value
 
-          Bullet.debug("Detector::NPlusOneQuery#add_inversed_object", "object: #{object.bullet_key}, association: #{association}")
+          Bullet.debug("Detector::NPlusOneQuery#add_inversed_object".freeze, "object: #{object.bullet_key}, association: #{association}")
           inversed_objects.add object.bullet_key, association
         end
 

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -29,7 +29,7 @@ module Bullet
           objects = Array(object_or_objects)
           return if objects.map(&:primary_key_value).compact.empty?
 
-          Bullet.debug("Detector::NPlusOneQuery#add_possible_objects", "objects: #{objects.map(&:bullet_key).join(', ')}")
+          Bullet.debug("Detector::NPlusOneQuery#add_possible_objects", "objects: #{objects.map(&:bullet_key).join(', '.freeze)}")
           objects.each { |object| possible_objects.add object.bullet_key }
         end
 

--- a/lib/bullet/ext/object.rb
+++ b/lib/bullet/ext/object.rb
@@ -5,7 +5,7 @@ class Object
 
   def primary_key_value
     if self.class.respond_to?(:primary_keys) && self.class.primary_keys
-      self.class.primary_keys.map { |primary_key| self.send primary_key }.join(',')
+      self.class.primary_keys.map { |primary_key| self.send primary_key }.join(','.freeze)
     elsif self.class.respond_to?(:primary_key) && self.class.primary_key
       self.send self.class.primary_key
     else

--- a/lib/bullet/ext/string.rb
+++ b/lib/bullet/ext/string.rb
@@ -1,5 +1,5 @@
 class String
   def bullet_class_name
-    self.sub(/:[^:]*?$/, "")
+    self.sub(/:[^:]*?$/, "".freeze)
   end
 end

--- a/lib/bullet/notification/base.rb
+++ b/lib/bullet/notification/base.rb
@@ -66,7 +66,7 @@ module Bullet
 
       protected
         def klazz_associations_str
-          "  #{@base_class} => [#{@associations.map(&:inspect).join(', ')}]"
+          "  #{@base_class} => [#{@associations.map(&:inspect).join(', '.freeze)}]"
         end
 
         def associations_str


### PR DESCRIPTION
A few strings are frozen to make fewer allocations. In a fairly big app, this saved 5k+ trivial allocations per request.