### PR TITLE
Don't serialise caller locations

### DIFF
--- a/lib/bullet/stack_trace_filter.rb
+++ b/lib/bullet/stack_trace_filter.rb
@@ -5,7 +5,8 @@ module Bullet
     def caller_in_project
       app_root = rails? ? Rails.root.to_s : Dir.pwd
       vendor_root = app_root + VENDOR_PATH
-      caller.select do |caller_path|
+      caller_locations.select do |location|
+        caller_path = location.absolute_path
         caller_path.include?(app_root) && !caller_path.include?(vendor_root) ||
           Bullet.stacktrace_includes.any? do |include_pattern|
           case include_pattern

--- a/spec/bullet/detector/n_plus_one_query_spec.rb
+++ b/spec/bullet/detector/n_plus_one_query_spec.rb
@@ -91,11 +91,11 @@ module Bullet
           after { Bullet.stacktrace_excludes = nil }
 
           it "should not create notification when stacktrace contains paths that are in the exclude list" do
-            in_project = File.join(Dir.pwd, 'abc', 'abc.rb')
-            included_path = '/ghi/ghi.rb'
-            excluded_path = '/def/def.rb'
+            in_project = OpenStruct.new(:absolute_path => File.join(Dir.pwd, 'abc', 'abc.rb'))
+            included_path = OpenStruct.new(:absolute_path => '/ghi/ghi.rb')
+            excluded_path = OpenStruct.new(:absolute_path => '/def/def.rb')
 
-            expect(NPlusOneQuery).to receive(:caller).and_return([in_project, included_path, excluded_path])
+            expect(NPlusOneQuery).to receive(:caller_locations).and_return([in_project, included_path, excluded_path])
             expect(NPlusOneQuery).to_not receive(:create_notification)
             NPlusOneQuery.call_association(@post, :association)
           end
@@ -104,10 +104,10 @@ module Bullet
 
       context ".caller_in_project" do
         it "should include only paths that are in the project" do
-          in_project = File.join(Dir.pwd, 'abc', 'abc.rb')
-          not_in_project = '/def/def.rb'
+          in_project = OpenStruct.new(:absolute_path => File.join(Dir.pwd, 'abc', 'abc.rb'))
+          not_in_project = OpenStruct.new(:absolute_path => '/def/def.rb')
 
-          expect(NPlusOneQuery).to receive(:caller).and_return([in_project, not_in_project])
+          expect(NPlusOneQuery).to receive(:caller_locations).and_return([in_project, not_in_project])
           expect(NPlusOneQuery).to receive(:conditions_met?).with(@post, :association).and_return(true)
           expect(NPlusOneQuery).to receive(:create_notification).with([in_project], "Post", :association)
           NPlusOneQuery.call_association(@post, :association)
@@ -118,11 +118,11 @@ module Bullet
           after { Bullet.stacktrace_includes = nil }
 
           it "should include paths that are in the stacktrace_include list" do
-            in_project = File.join(Dir.pwd, 'abc', 'abc.rb')
-            included_gems = ['/def/def.rb', 'xyz/xyz.rb']
-            excluded_gem = '/ghi/ghi.rb'
+            in_project = OpenStruct.new(:absolute_path => File.join(Dir.pwd, 'abc', 'abc.rb'))
+            included_gems = [OpenStruct.new(:absolute_path => '/def/def.rb'), OpenStruct.new(:absolute_path => 'xyz/xyz.rb')]
+            excluded_gem = OpenStruct.new(:absolute_path => '/ghi/ghi.rb')
 
-            expect(NPlusOneQuery).to receive(:caller).and_return([in_project, *included_gems, excluded_gem])
+            expect(NPlusOneQuery).to receive(:caller_locations).and_return([in_project, *included_gems, excluded_gem])
             expect(NPlusOneQuery).to receive(:conditions_met?).with(@post, :association).and_return(true)
             expect(NPlusOneQuery).to receive(:create_notification).with([in_project, *included_gems], "Post", :association)
             NPlusOneQuery.call_association(@post, :association)


### PR DESCRIPTION
Since the filter is only interested in the path, it can be extracted
from the Location object, rather than a string representing it.
This reduces the memory usage of that file to 1/3.
(3MB to 1MB per request in a large app)