### PR TITLE
Fix Rails 5 false positive for intermediate (through) associations

### DIFF
--- a/lib/bullet/active_record5.rb
+++ b/lib/bullet/active_record5.rb
@@ -187,8 +187,8 @@ module Bullet
 
       ::ActiveRecord::Associations::SingularAssociation.prepend(Module.new {
         # call has_one and belongs_to associations
-        def reader(force_reload = false)
-          result = force_reload ? force_reload_reader : super()
+        def target
+          result = super()
           if Bullet.start?
             if owner.class.name !~ /^HABTM_/ && !@inversed
               Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name)


### PR DESCRIPTION
When you `preload` a `has_one :through` association, Rails loads the intermediate association followed by the source association.

Rails 5 [changed how the intermediate results are accessed](https://github.com/rails/rails/commit/842f5c2dad8ed021274c16f2dc231c15ddefba18) during preloading such that `#reader` is bypassed. As a result, Bullet is unaware that these associations have been accessed (i.e. `Bullet::Detector::NPlusOneQuery.call_association` isn't called).

This results in false positive avoid eager loading warnings from the model to the intermediate association as well as from the intermediate association to the source association.

More details in #323 

This PR addresses the issue by overriding `target` instead of `reader`, so that the access to intermediate associations is tracked

I'm not super-familiar with the Bullet source, so I'm not sure if this has unintended consequences, but I'm starting a PR so others can chime in. Thanks.

Closes #323