### PR TITLE
Fix caller path in the case of nil

### DIFF
--- a/lib/bullet/stack_trace_filter.rb
+++ b/lib/bullet/stack_trace_filter.rb
@@ -6,7 +6,7 @@ module Bullet
       app_root = rails? ? Rails.root.to_s : Dir.pwd
       vendor_root = app_root + VENDOR_PATH
       caller_locations.select do |location|
-        caller_path = location.absolute_path
+        caller_path = location.absolute_path.to_s
         caller_path.include?(app_root) && !caller_path.include?(vendor_root) ||
           Bullet.stacktrace_includes.any? do |include_pattern|
           case include_pattern


### PR DESCRIPTION
We updated bullet to 5.6.0 at own project, but we have received below exception.

```
NoMethodError: undefined method `include?' for nil:NilClass
from /Users/yukihattori/.anyenv/envs/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bullet-5.6.0/lib/bullet/stack_trace_filter.rb:10:in `block in caller_in_project'
```

According to the source code of Ruby,  [`Thread::Backtrace::Location#absolute_path` seems to be able to return `nil`](https://github.com/brightbox/deb-ruby2.3/blob/master/vm_backtrace.c#L241). It would become raising `NoMethodError` at `include?`. I could not find the procedure for reproducing clearly because I'm not familiar with Ruby core.

We would be able to deal with it by using `to_s` to convert from `nil` to empty string.