### PR TITLE
Minor refactoring

### DIFF
--- a/lib/bullet/stack_trace_filter.rb
+++ b/lib/bullet/stack_trace_filter.rb
@@ -1,6 +1,6 @@
 module Bullet
   module StackTraceFilter
-    VENDOR_PATH = "/vendor"
+    VENDOR_PATH = "/vendor".freeze
 
     def caller_in_project
       app_root = rails? ? Rails.root.to_s : Dir.pwd

--- a/lib/bullet/version.rb
+++ b/lib/bullet/version.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 module Bullet
   VERSION = "5.6.0"
 end

--- a/lib/bullet/version.rb
+++ b/lib/bullet/version.rb
@@ -1,3 +1,3 @@
 module Bullet
-  VERSION = "5.6.0"
+  VERSION = "5.6.0".freeze
 end

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'spec_helper'
 
 module Bullet


### PR DESCRIPTION
- Many of files in this gem don't support magic comments. So I've removed magic comments `encoding: utf-8` from 2 files. ~And though all files don't have magic comments, gemspec don't define required ruby version. Therefore I've define required ruby version ">= 2.0.0".~ Sorry, I've misunderstood. If it have no magic comments, string encoding is US ASCII. So, we don't need to set require ruby version.
- I've modified string of constants be freezing string.

@flyerhzm please review this request (And please bump v5.6.1 which including #345 if it was merged this request)