### PR TITLE
Update uniform_notifier dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next Release
 
+## 5.7.0 (13/11/2017)
+
+* Update `uniform_notifier` dependencyto add Sentry support
+
 ## 5.6.1 (08/01/2017)
 
 * Fix caller_path in the case of nil

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Bullet won't do ANYTHING unless you tell it to explicitly. Append to
 ```ruby
 config.after_initialize do
   Bullet.enable = true
+  Bullet.sentry = true
   Bullet.alert = true
   Bullet.bullet_logger = true
   Bullet.console = true
@@ -82,6 +83,7 @@ The code above will enable all of the Bullet notification systems:
 * `Bullet.bugsnag`: add notifications to bugsnag
 * `Bullet.airbrake`: add notifications to airbrake
 * `Bullet.rollbar`: add notifications to rollbar
+* `Bullet.sentry`: add notifications to sentry
 * `Bullet.add_footer`: adds the details in the bottom left corner of the page. Double click the footer or use close button to hide footer.
 * `Bullet.stacktrace_includes`: include paths with any of these substrings in the stack trace, even if they are not in your main app
 * `Bullet.stacktrace_excludes`: ignore paths with any of these substrings in the stack trace, even if they are not in your main app.

--- a/bullet.gemspec
+++ b/bullet.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
 
   s.add_runtime_dependency 'activesupport', '>= 3.0.0'
-  s.add_runtime_dependency 'uniform_notifier', '~> 1.10.0'
+  s.add_runtime_dependency 'uniform_notifier', '~> 1.11.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/bullet/version.rb
+++ b/lib/bullet/version.rb
@@ -1,4 +1,4 @@
 
 module Bullet
-  VERSION = '5.6.1'.freeze
+  VERSION = '5.7.0'.freeze
 end


### PR DESCRIPTION
Following your comment [here](https://github.com/flyerhzm/uniform_notifier/issues/37), I tried to update the `uniform_notifier` without bumping the version of `Bullet`, but I can't make it works.

Maybe it's because `uniform_notifier` is specified in `bullet.gemspec`?