### PR TITLE
Implement Bullet.delete_whitelist to delete a specific whitelist definition

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -87,6 +87,13 @@ module Bullet
       @whitelist[options[:type]][options[:class_name]] << options[:association].to_sym
     end
 
+    def delete_whitelist(options)
+      reset_whitelist
+      @whitelist[options[:type]][options[:class_name]] ||= []
+      @whitelist[options[:type]][options[:class_name]].delete(options[:association].to_sym)
+      @whitelist[options[:type]].delete_if { |key, val| val.empty? }
+    end
+
     def get_whitelist_associations(type, class_name)
       Array(@whitelist[type][class_name])
     end

--- a/spec/bullet_spec.rb
+++ b/spec/bullet_spec.rb
@@ -94,6 +94,26 @@ describe Bullet, focused: true do
     end
   end
 
+  describe '#delete_whitelist' do
+    context "for 'special' class names" do
+      it 'is deleted from the whitelist successfully' do
+        Bullet.add_whitelist(:type => :n_plus_one_query, :class_name => 'Klass', :association => :department)
+        Bullet.delete_whitelist(:type => :n_plus_one_query, :class_name => 'Klass', :association => :department)
+        expect(Bullet.whitelist[:n_plus_one_query]).to eq({})
+      end
+    end
+
+    context 'when exists multiple definitions' do
+      it 'is deleted from the whitelist successfully' do
+        Bullet.add_whitelist(:type => :n_plus_one_query, :class_name => 'Klass', :association => :department)
+        Bullet.add_whitelist(:type => :n_plus_one_query, :class_name => 'Klass', :association => :team)
+        Bullet.delete_whitelist(:type => :n_plus_one_query, :class_name => 'Klass', :association => :team)
+        expect(Bullet.get_whitelist_associations(:n_plus_one_query, 'Klass')).to include :department
+        expect(Bullet.get_whitelist_associations(:n_plus_one_query, 'Klass')).to_not include :team
+      end
+    end
+  end
+
   describe '#perform_out_of_channel_notifications' do
     let(:notification) { double }
 


### PR DESCRIPTION
Hi there,

I use Bullet gem with RSpec gem.
Rarely I want to enable a whitelist definition temporary in my spec.

For example, for feature toggle which completely separate the logic.
And then, Bullet warns me "N+1 DETECTED" at feature A spec. On the other side, Bullet warns me "AVOID UNUSED EAGER LOADING" at feature B spec.
So, I add the whitelist definition temporary in my spec, and after the spec running, I want to delete the whitelist definition not clear all definitions.

```ruby
describe 'User#some_method' do
  subject { user.some_method }
  context 'when feature A is enabled' do
    before { Bullet.add_whitelist type: :n_plus_one_query, class_name: 'User', association: :profile }
    after    { Bullet.delete_whitelist type: :n_plus_one_query, class_name: 'User', association: :profile }
    ...
  end
  context 'when feature B is enabled' do
    before { Bullet.add_whitelist type: :n_plus_one_query, class_name: 'User', association: :setting }
    after    { Bullet.delete_whitelist type: :n_plus_one_query, class_name: 'User', association: :setting }
    ...
  end
end
```

Could you review this feature?

Thanks,