### PR TITLE
Suppress warnings

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -29,13 +29,13 @@ module Bullet
   end
 
   class << self
-    attr_writer :enable, :n_plus_one_query_enable, :unused_eager_loading_enable, :counter_cache_enable, :stacktrace_includes, :stacktrace_excludes
-    attr_reader :notification_collector, :whitelist
+    attr_writer :n_plus_one_query_enable, :unused_eager_loading_enable, :counter_cache_enable, :stacktrace_includes, :stacktrace_excludes
+    attr_reader :whitelist
     attr_accessor :add_footer, :orm_pathches_applied
 
     available_notifiers = UniformNotifier::AVAILABLE_NOTIFIERS.map { |notifier| "#{notifier}=" }
     available_notifiers << { :to => UniformNotifier }
-    delegate *available_notifiers
+    delegate(*available_notifiers)
 
     def raise=(should_raise)
       UniformNotifier.raise = (should_raise ? Notification::UnoptimizedQueryError : false)


### PR DESCRIPTION
This PR suppresses the following warning.

```
ruby -v
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-darwin16]

RUBYOPT=-w bundle exec rake 
/Users/numata/git/github.com/flyerhzm/bullet/lib/bullet.rb:38: warning: `*' interpreted as argument prefix
/Users/numata/git/github.com/flyerhzm/bullet/lib/bullet.rb:48: warning: method redefined; discarding old enable=
/Users/numata/git/github.com/flyerhzm/bullet/lib/bullet.rb:158: warning: method redefined; discarding old notification_collector
```