### PR TITLE
Fix dependency for rails 5-1-stable

### DIFF
--- a/lib/bullet/dependency.rb
+++ b/lib/bullet/dependency.rb
@@ -23,7 +23,7 @@ module Bullet
                                    elsif active_record50?
                                      'active_record5'
                                    elsif active_record51?
-                                     'active_record5'
+                                     'active_record52'
                                    elsif active_record52?
                                      'active_record52'
                                    else


### PR DESCRIPTION
Hi,

We're running rails 5-1-stable and we were getting some `ArgumentError:         ArgumentError: wrong number of arguments (given 1, expected 2)` exceptions. I dug down and found that bullet should require the activerecord52 dependency instead of the activerecord5 dependency for rails 5.1 stable.

Rails 5-1-stable : https://github.com/rails/rails/blob/5-1-stable/activerecord/lib/active_record/associations/join_dependency.rb#L137

Bullet 5 : https://github.com/agendrix/bullet/blob/master/lib/bullet/active_record5.rb#L96
Bullet 52 : https://github.com/agendrix/bullet/blob/master/lib/bullet/active_record52.rb#L96

Filename should probably be renamed to activerecord51.rb too