### PR TITLE
Exclude configured bundler path in addition to '/vendor'

### DIFF
--- a/lib/bullet/stack_trace_filter.rb
+++ b/lib/bullet/stack_trace_filter.rb
@@ -5,9 +5,10 @@ module Bullet
     def caller_in_project
       app_root = rails? ? Rails.root.to_s : Dir.pwd
       vendor_root = app_root + VENDOR_PATH
+      bundler_path = Bundler.bundle_path.to_s
       caller_locations.select do |location|
         caller_path = location.absolute_path.to_s
-        caller_path.include?(app_root) && !caller_path.include?(vendor_root) ||
+        caller_path.include?(app_root) && !caller_path.include?(vendor_root) && !caller_path.include?(bundler_path) ||
           Bullet.stacktrace_includes.any? do |include_pattern|
             case include_pattern
             when String


### PR DESCRIPTION
Seems like bullet only excludes a hardcoded /vendor path, while my setup puts things under /.bundle. The Bullet.stacktrace_excludes doesn't clean out all those lines as I thought it would, so adding it this way cleans up my logs tremendously. Hopefully this PR will be helpful for others!