### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/bullet.gemspec
+++ b/bullet.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Richard Huang']
   s.email       = ['flyerhzm@gmail.com']
-  s.homepage    = 'http://github.com/flyerhzm/bullet'
+  s.homepage    = 'https://github.com/flyerhzm/bullet'
   s.summary     = 'help to kill N+1 queries and unused eager loading.'
   s.description = 'help to kill N+1 queries and unused eager loading.'
 


### PR DESCRIPTION
This reduces an unneeded redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/bullet