### PR TITLE
Avoid Bullet from making extra queries in mongoid6

### DIFF
--- a/lib/bullet/mongoid6x.rb
+++ b/lib/bullet/mongoid6x.rb
@@ -21,13 +21,15 @@ module Bullet
         end
 
         def each(&block)
-          records = view.map { |doc| ::Mongoid::Factory.from_db(klass, doc) }
+          return to_enum unless block_given?
+          records = []
+          origin_each { |record| records << record }
           if records.length > 1
             Bullet::Detector::NPlusOneQuery.add_possible_objects(records)
           elsif records.size == 1
             Bullet::Detector::NPlusOneQuery.add_impossible_object(records.first)
           end
-          origin_each(&block)
+          records.each(&block)
         end
 
         def eager_load(docs)


### PR DESCRIPTION
Currently with mongoid6 bullet repeats every query

Fixes #331 and #385 