### PR TITLE
Fixes error message when using unsupported AR.

### DIFF
--- a/lib/bullet/dependency.rb
+++ b/lib/bullet/dependency.rb
@@ -29,7 +29,7 @@ module Bullet
                                    elsif active_record52?
                                      'active_record52'
                                    else
-                                     raise "Bullet does not support active_record #{::ActiveRecord::VERSION} yet"
+                                     raise "Bullet does not support active_record #{::ActiveRecord::VERSION::STRING} yet"
                                    end
                                  end
     end


### PR DESCRIPTION
When trying to use an unsupported ActiveRecord version, currently the gem blurts out this:

`Gem Load Error is: Bullet does not support active_record ActiveRecord::VERSION yet`

We should use `ActiveRecord::VERSION::STRING` in the interpolation. [`::STRING`](https://github.com/rails/rails/blob/1c383df324fdf0b68b3f54a649eb7d2a4f55bcb7/activerecord/lib/active_record/gem_version.rb#L15 ) resolves to a proper version (like `5.2.0`), so the error message would be something like: 

 `Gem Load Error is: Bullet does not support active_record 5.2.0 yet`
