### PR TITLE
[Enhance] Check If Primary Id not Accessible When Selector is Applied

### DIFF
--- a/lib/bullet/ext/object.rb
+++ b/lib/bullet/ext/object.rb
@@ -11,7 +11,7 @@ class Object
     elsif self.class.respond_to?(:primary_key) && self.class.primary_key
       send self.class.primary_key
     else
-      id
+      id rescue nil
     end
   end
 end

--- a/spec/bullet/ext/object_spec.rb
+++ b/spec/bullet/ext/object_spec.rb
@@ -23,6 +23,11 @@ describe Object do
       expect(post.primary_key_value).to eq(post.id)
     end
 
+    it 'should return nil when id field not select' do
+      post = Post.select(:name).first
+      expect(post.primary_key_value).to eq(nil)
+    end
+
     it 'should return primary key value' do
       post = Post.first
       Post.primary_key = 'name'


### PR DESCRIPTION
### Objective

This is to check when selection is applied when `id` is not selected might throw some errors

### Feature

- Added exceptional case
- Added spec