### PR TITLE
extend stacktrace matching for sub-file precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ config.after_initialize do
   Bullet.rollbar = true
   Bullet.add_footer = true
   Bullet.stacktrace_includes = [ 'your_gem', 'your_middleware' ]
-  Bullet.stacktrace_excludes = [ 'their_gem', 'their_middleware' ]
+  Bullet.stacktrace_excludes = [ 'their_gem', 'their_middleware', ['my_file.rb', 'my_method'], ['my_file.rb', 16..20] ]
   Bullet.slack = { webhook_url: 'http://some.slack.url', channel: '#default', username: 'notifier' }
 end
 ```
@@ -87,6 +87,8 @@ The code above will enable all of the Bullet notification systems:
 * `Bullet.add_footer`: adds the details in the bottom left corner of the page. Double click the footer or use close button to hide footer.
 * `Bullet.stacktrace_includes`: include paths with any of these substrings in the stack trace, even if they are not in your main app
 * `Bullet.stacktrace_excludes`: ignore paths with any of these substrings in the stack trace, even if they are not in your main app.
+   Each item can be a string (match substring), a regex, or an array where the first item is a path to match, and the second
+   item is a line number, a Range of line numbers, or a (bare) method name, to exclude only particular lines in a file.
 * `Bullet.slack`: add notifications to slack
 * `Bullet.raise`: raise errors, useful for making your specs fail unless they have optimized queries
 

--- a/lib/bullet/stack_trace_filter.rb
+++ b/lib/bullet/stack_trace_filter.rb
@@ -8,46 +8,65 @@ module Bullet
       app_root = rails? ? Rails.root.to_s : Dir.pwd
       vendor_root = app_root + VENDOR_PATH
       bundler_path = Bundler.bundle_path.to_s
-      select_caller_locations do |caller_path|
+      select_caller_locations do |location|
+        caller_path = location_as_path(location)
         caller_path.include?(app_root) && !caller_path.include?(vendor_root) && !caller_path.include?(bundler_path) ||
-          Bullet.stacktrace_includes.any? do |include_pattern|
-            case include_pattern
-            when String
-              caller_path.include?(include_pattern)
-            when Regexp
-              caller_path =~ include_pattern
-            end
-          end
+          Bullet.stacktrace_includes.any? { |include_pattern| pattern_matches?(location, include_pattern) }
       end
     end
 
     def excluded_stacktrace_path?
       Bullet.stacktrace_excludes.any? do |exclude_pattern|
-        caller_in_project.any? do |location|
-          caller_path = location.absolute_path.to_s
-          case exclude_pattern
-          when String
-            caller_path.include?(exclude_pattern)
-          when Regexp
-            caller_path =~ exclude_pattern
-          end
-        end
+        caller_in_project.any? { |location| pattern_matches?(location, exclude_pattern) }
       end
     end
 
     private
 
+    def pattern_matches?(location, pattern)
+      path = location_as_path(location)
+      case pattern
+      when Array
+        pattern_path = pattern.first
+        filter = pattern.last
+        return false unless pattern_matches?(location, pattern_path)
+
+        case filter
+        when Range
+          filter.include?(location.lineno)
+        when Integer
+          filter == location.lineno
+        when String
+          filter == location.base_label
+        end
+      when String
+        path.include?(pattern)
+      when Regexp
+        path =~ pattern
+      end
+    end
+
+    def location_as_path(location)
+      ruby_19? ? location : location.absolute_path.to_s
+    end
+
     def select_caller_locations
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+      if ruby_19?
         caller.select do |caller_path|
           yield caller_path
         end
       else
         caller_locations.select do |location|
-          caller_path = location.absolute_path.to_s
-          yield caller_path
+          yield location
         end
       end
+    end
+
+    def ruby_19?
+      if @ruby_19.nil?
+        @ruby_19 = Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+      end
+      @ruby_19
     end
   end
 end


### PR DESCRIPTION
it's not uncommon to have code that preloads (or not) for the common case,
but for certain data layouts it will generate a Bullet warning. it should
be possible to exclude just that small piece of code, rather than all
violations in the entire file