### PR TITLE
fix false positive in convoluted after_save callback

### DIFF
--- a/lib/bullet/active_record4.rb
+++ b/lib/bullet/active_record4.rb
@@ -179,7 +179,9 @@ module Bullet
           if Bullet.start?
             unless @inversed
               Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name)
-              Bullet::Detector::NPlusOneQuery.add_possible_objects(result)
+              if Bullet::Detector::NPlusOneQuery.possible?(@owner)
+                Bullet::Detector::NPlusOneQuery.add_possible_objects(result)
+              end
             end
           end
           result

--- a/lib/bullet/active_record41.rb
+++ b/lib/bullet/active_record41.rb
@@ -170,7 +170,9 @@ module Bullet
           if Bullet.start?
             if @owner.class.name !~ /^HABTM_/ && !@inversed
               Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name)
-              Bullet::Detector::NPlusOneQuery.add_possible_objects(result)
+              if Bullet::Detector::NPlusOneQuery.possible?(@owner)
+                Bullet::Detector::NPlusOneQuery.add_possible_objects(result)
+              end
             end
           end
           result

--- a/lib/bullet/active_record42.rb
+++ b/lib/bullet/active_record42.rb
@@ -219,7 +219,7 @@ module Bullet
               Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name)
               if Bullet::Detector::NPlusOneQuery.impossible?(@owner)
                 Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
-              else
+              elsif Bullet::Detector::NPlusOneQuery.possible?(@owner)
                 Bullet::Detector::NPlusOneQuery.add_possible_objects(result) if result
               end
             end

--- a/lib/bullet/active_record5.rb
+++ b/lib/bullet/active_record5.rb
@@ -212,7 +212,7 @@ module Bullet
               Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name)
               if Bullet::Detector::NPlusOneQuery.impossible?(owner)
                 Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
-              else
+              elsif Bullet::Detector::NPlusOneQuery.possible?(owner)
                 Bullet::Detector::NPlusOneQuery.add_possible_objects(result) if result
               end
             end

--- a/lib/bullet/active_record52.rb
+++ b/lib/bullet/active_record52.rb
@@ -195,7 +195,7 @@ module Bullet
               Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name)
               if Bullet::Detector::NPlusOneQuery.impossible?(owner)
                 Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
-              else
+              elsif Bullet::Detector::NPlusOneQuery.possible?(owner)
                 Bullet::Detector::NPlusOneQuery.add_possible_objects(result) if result
               end
             end

--- a/spec/integration/active_record/association_spec.rb
+++ b/spec/integration/active_record/association_spec.rb
@@ -356,6 +356,16 @@ if active_record?
 
         expect(Bullet::Detector::Association).to be_completely_preloading_associations
       end
+
+      it 'should not detect newly assigned object in an after_save' do
+        new_post = Post.new(category: Category.first)
+
+        new_post.trigger_after_save = true
+        new_post.save!
+        expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
+
+        expect(Bullet::Detector::Association).to be_completely_preloading_associations
+      end
     end
 
     context 'comment => post => category' do

--- a/spec/models/post.rb
+++ b/spec/models/post.rb
@@ -14,4 +14,19 @@ class Post < ActiveRecord::Base
   def link=(*)
     comments.new
   end
+
+  # see association_spec.rb 'should not detect newly assigned object in an after_save'
+  attr_accessor :trigger_after_save
+  after_save do
+    next unless trigger_after_save
+
+    temp_comment = Comment.new(post: self)
+    # this triggers self to be "possible", even though it's
+    # not saved yet
+    temp_comment.post
+
+    # category should NOT whine about not being pre-loaded, because
+    # it's obviously attached to a new object
+    category
+  end
 end


### PR DESCRIPTION
the key trigger here is that in an after_save callback self has an ID, but is not yet marked as impossible. so accessing associations that look at it need to ignore objects that are neither possible nor impossible