### PR TITLE
Update skip_bullet in readme to use previous value

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ class ApplicationController < ActionController::Base
   around_action :skip_bullet
 
   def skip_bullet
+    previous_value = Bullet.enabled?
     Bullet.enable = false
     yield
   ensure
-    Bullet.enable = true
+    Bullet.enable = previous_value
   end
 end
 ```


### PR DESCRIPTION
As it currently stands, the skip_bullet function in the readme will always result in bullet being enabled, even if it was originally disabled.