### PR TITLE
Support a option for `Mongoid::Contextual::Mongo#first` and `#last` on mongoid6.x

### DIFF
--- a/lib/bullet/mongoid6x.rb
+++ b/lib/bullet/mongoid6x.rb
@@ -10,14 +10,14 @@ module Bullet
         alias_method :origin_each, :each
         alias_method :origin_eager_load, :eager_load
 
-        def first
-          result = origin_first
+        def first(opt = {})
+          result = origin_first(opt)
           Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
           result
         end
 
-        def last
-          result = origin_last
+        def last(opt = {})
+          result = origin_last(opt)
           Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
           result
         end


### PR DESCRIPTION
I've got the following `ArgumentError` on mongoid v6.4.1 and bullet v5.7.6.

```
ArgumentError: wrong number of arguments (given 1, expected 0)
from /sample/example/bullet-5.7.6/lib/bullet/mongoid6x.rb:13:in `first
```

Because mongoid6.x changed to support a option argument for `Mongoid::Contextual::Mongo#first` and `#last`. https://github.com/mongodb/mongoid/commit/346316d7f139300ab0dfafe5a6cf105176942e8f#diff-9f2758fc31a36227f2e9932b142db328R237

So I added the argument to bullet.