### PR TITLE
Fix multiple through bug

### DIFF
--- a/lib/bullet/active_record5.rb
+++ b/lib/bullet/active_record5.rb
@@ -161,10 +161,19 @@ module Bullet
 
           if Bullet.start?
             if is_a? ::ActiveRecord::Associations::ThroughAssociation
-              Bullet::Detector::NPlusOneQuery.call_association(owner, through_reflection.name)
-              association = owner.association through_reflection.name
+              refl = reflection.through_reflection
+              Bullet::Detector::NPlusOneQuery.call_association(owner, refl.name)
+              association = owner.association refl.name
               Array(association.target).each do |through_record|
                 Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+              end
+
+              if refl.through_reflection?
+                while refl.through_reflection?
+                  refl = refl.through_reflection
+                end
+
+                Bullet::Detector::NPlusOneQuery.call_association(owner, refl.name)
               end
             end
             Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name) unless @inversed

--- a/lib/bullet/active_record52.rb
+++ b/lib/bullet/active_record52.rb
@@ -144,10 +144,14 @@ module Bullet
 
           if Bullet.start?
             if is_a? ::ActiveRecord::Associations::ThroughAssociation
-              Bullet::Detector::NPlusOneQuery.call_association(owner, through_reflection.name)
-              association = owner.association through_reflection.name
+              Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
+              association = owner.association reflection.through_reflection.name
               Array(association.target).each do |through_record|
                 Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+              end
+
+              if reflection.through_reflection != through_reflection
+                Bullet::Detector::NPlusOneQuery.call_association(owner, through_reflection.name)
               end
             end
             Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name) unless @inversed

--- a/spec/integration/active_record/association_spec.rb
+++ b/spec/integration/active_record/association_spec.rb
@@ -550,6 +550,44 @@ if active_record?
         expect(Bullet::Detector::Association).to be_completely_preloading_associations
       end
     end
+
+    context 'firm => clients => groups' do
+      it 'should detect non preload associations' do
+        Firm.all.each do |firm|
+          firm.groups.map(&:name)
+        end
+        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
+        expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
+
+        expect(Bullet::Detector::Association).to be_detecting_unpreloaded_association_for(Firm, :groups)
+      end
+
+      it 'should detect preload associations' do
+        Firm.includes(:groups).each do |firm|
+          firm.groups.map(&:name)
+        end
+        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
+        expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
+
+        expect(Bullet::Detector::Association).to be_completely_preloading_associations
+      end
+
+      it 'should not detect preload associations' do
+        Firm.all.map(&:name)
+        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
+        expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
+
+        expect(Bullet::Detector::Association).to be_completely_preloading_associations
+      end
+
+      it 'should detect unused preload associations' do
+        Firm.includes(:groups).map(&:name)
+        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
+        expect(Bullet::Detector::Association).to be_unused_preload_associations_for(Firm, :groups)
+
+        expect(Bullet::Detector::Association).to be_completely_preloading_associations
+      end
+    end
   end
 
   describe Bullet::Detector::Association, 'has_one' do

--- a/spec/models/client.rb
+++ b/spec/models/client.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Client < ActiveRecord::Base
+  belongs_to :group
+
   has_many :relationships
   has_many :firms, through: :relationships
 end

--- a/spec/models/firm.rb
+++ b/spec/models/firm.rb
@@ -3,4 +3,5 @@
 class Firm < ActiveRecord::Base
   has_many :relationships
   has_many :clients, through: :relationships
+  has_many :groups, through: :clients
 end

--- a/spec/models/group.rb
+++ b/spec/models/group.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Group < ActiveRecord::Base
+end

--- a/spec/support/sqlite_seed.rb
+++ b/spec/support/sqlite_seed.rb
@@ -45,8 +45,10 @@ module Support
 
       firm1 = Firm.create(name: 'first')
       firm2 = Firm.create(name: 'second')
-      client1 = Client.create(name: 'first')
-      client2 = Client.create(name: 'second')
+      group1 = Group.create(name: 'first')
+      group2 = Group.create(name: 'second')
+      client1 = Client.create(name: 'first', group: group1)
+      client2 = Client.create(name: 'second', group: group2)
       firm1.clients = [client1, client2]
       firm2.clients = [client1, client2]
       client1.firms << firm1
@@ -125,6 +127,7 @@ module Support
 
         create_table :clients do |t|
           t.column :name, :string
+          t.column :group_id, :integer
         end
 
         create_table :comments do |t|
@@ -168,6 +171,10 @@ module Support
         end
 
         create_table :firms do |t|
+          t.column :name, :string
+        end
+
+        create_table :groups do |t|
           t.column :name, :string
         end
 


### PR DESCRIPTION
I found a wrong detection when set nested "through" to "includes" at ActiveRecord 5.2.
Because "#through_reflection" was changed.

(AR5.1)
https://github.com/rails/rails/blob/5-1-stable/activerecord/lib/active_record/associations/through_association.rb#L5

(AR5.2)
https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/associations/through_association.rb#L10-L20