### PR TITLE
Require Ruby 2.3+ in  in gemspec

### DIFF
--- a/bullet.gemspec
+++ b/bullet.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
+  s.required_ruby_version = '>= 2.3'
   s.required_rubygems_version = '>= 1.3.6'
 
   s.add_runtime_dependency 'activesupport', '>= 3.0.0'


### PR DESCRIPTION
This https://github.com/flyerhzm/bullet/commit/3ab8e3a2ac67d9dcbcdcb0dbe4510252b09af739 commit broke the gem for Ruby 2.2 and below, as the safe navigation operator was added only in Ruby 2.3.

I'm aware Ruby 2.2 is EOL but it may brake people's projects (it broke one of mine).