### PR TITLE
Auto corrected by following Ruby EmptyLine

### DIFF
--- a/lib/bullet/mongoid7x.rb
+++ b/lib/bullet/mongoid7x.rb
@@ -24,6 +24,7 @@ module Bullet
 
         def each(&block)
           return to_enum unless block_given?
+
           records = []
           origin_each { |record| records << record }
           if records.length > 1


### PR DESCRIPTION
Auto corrected by following Ruby EmptyLine

Click [here](https://awesomecode.io/repos/flyerhzm/bullet/ruby_config_groups/49) to configure it on awesomecode.io