### PR TITLE
Add missing `check_unused_preload_associations` call to spec

### DIFF
--- a/lib/bullet/active_record4.rb
+++ b/lib/bullet/active_record4.rb
@@ -191,14 +191,6 @@ module Bullet
         end
         # rubocop:enable Style/MethodCallWithoutArgsParentheses
       end
-
-      ::ActiveRecord::Associations::BelongsToAssociation.class_eval do
-        def writer_with_bullet(record)
-          Bullet::Detector::Association.add_object_associations(owner, reflection.name) if Bullet.start?
-          writer_without_bullet(record)
-        end
-        alias_method_chain :writer, :bullet
-      end
     end
   end
 end

--- a/lib/bullet/active_record41.rb
+++ b/lib/bullet/active_record41.rb
@@ -179,14 +179,6 @@ module Bullet
           origin_count_records
         end
       end
-
-      ::ActiveRecord::Associations::BelongsToAssociation.class_eval do
-        def writer_with_bullet(record)
-          Bullet::Detector::Association.add_object_associations(owner, reflection.name) if Bullet.start?
-          writer_without_bullet(record)
-        end
-        alias_method_chain :writer, :bullet
-      end
     end
   end
 end

--- a/lib/bullet/active_record42.rb
+++ b/lib/bullet/active_record42.rb
@@ -240,14 +240,6 @@ module Bullet
           origin_count_records
         end
       end
-
-      ::ActiveRecord::Associations::BelongsToAssociation.class_eval do
-        def writer_with_bullet(record)
-          Bullet::Detector::Association.add_object_associations(owner, reflection.name) if Bullet.start?
-          writer_without_bullet(record)
-        end
-        alias_method_chain :writer, :bullet
-      end
     end
   end
 end

--- a/lib/bullet/active_record5.rb
+++ b/lib/bullet/active_record5.rb
@@ -240,13 +240,6 @@ module Bullet
           super
         end
       end)
-
-      ::ActiveRecord::Associations::BelongsToAssociation.prepend(Module.new do
-        def writer(record)
-          Bullet::Detector::Association.add_object_associations(owner, reflection.name) if Bullet.start?
-          super
-        end
-      end)
     end
   end
 end

--- a/lib/bullet/active_record52.rb
+++ b/lib/bullet/active_record52.rb
@@ -220,13 +220,6 @@ module Bullet
           super
         end
       end)
-
-      ::ActiveRecord::Associations::BelongsToAssociation.prepend(Module.new do
-        def writer(record)
-          Bullet::Detector::Association.add_object_associations(owner, reflection.name) if Bullet.start?
-          super
-        end
-      end)
     end
   end
 end

--- a/spec/integration/active_record/association_spec.rb
+++ b/spec/integration/active_record/association_spec.rb
@@ -367,18 +367,6 @@ if active_record?
 
         expect(Bullet::Detector::Association).to be_completely_preloading_associations
       end
-
-      it 'should not detect "manual" preload' do
-        comment = Comment.all.to_a.first
-        post = Post.find(comment.post_id)
-        # "manually" preload with out-of-band data
-        comment.post = post
-        # loading it should not trigger anything
-        comment.post
-        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
-        expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
-        expect(Bullet::Detector::Association).to be_completely_preloading_associations
-      end
     end
 
     context 'comment => post => category' do

--- a/spec/integration/active_record/association_spec.rb
+++ b/spec/integration/active_record/association_spec.rb
@@ -331,7 +331,7 @@ if active_record?
         expect(Bullet::Detector::Association).to be_completely_preloading_associations
       end
 
-      it 'should dtect preload with comment => post' do
+      it 'should detect preload with comment => post' do
         Comment.includes(:post).each do |comment|
           comment.post.name
         end
@@ -362,6 +362,7 @@ if active_record?
 
         new_post.trigger_after_save = true
         new_post.save!
+        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
         expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
 
         expect(Bullet::Detector::Association).to be_completely_preloading_associations
@@ -374,7 +375,7 @@ if active_record?
         comment.post = post
         # loading it should not trigger anything
         comment.post
-
+        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
         expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
         expect(Bullet::Detector::Association).to be_completely_preloading_associations
       end


### PR DESCRIPTION
Spec in 582b2d4b actually not passes, which I fixed at 314a43d (CI red).

After reverting the commit, other specs are still good. 