### PR TITLE
Make Rails check more specific

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -63,6 +63,10 @@ module Bullet
       !!@enable
     end
 
+    def app_root
+      (defined?(::Rails.root) ? Rails.root.to_s : Dir.pwd).to_s
+    end
+
     def n_plus_one_query_enable?
       enable? && !!@n_plus_one_query_enable
     end
@@ -111,9 +115,8 @@ module Bullet
     def bullet_logger=(active)
       if active
         require 'fileutils'
-        root_path = (rails? ? Rails.root.to_s : Dir.pwd).to_s
-        FileUtils.mkdir_p(root_path + '/log')
-        bullet_log_file = File.open("#{root_path}/log/bullet.log", 'a+')
+        FileUtils.mkdir_p(app_root + '/log')
+        bullet_log_file = File.open("#{app_root}/log/bullet.log", 'a+')
         bullet_log_file.sync = true
         UniformNotifier.customized_logger = bullet_log_file
       end

--- a/lib/bullet/dependency.rb
+++ b/lib/bullet/dependency.rb
@@ -10,10 +10,6 @@ module Bullet
       @active_record ||= defined? ::ActiveRecord
     end
 
-    def rails?
-      @rails ||= defined? ::Rails
-    end
-
     def active_record_version
       @active_record_version ||= begin
                                    if active_record40?

--- a/lib/bullet/stack_trace_filter.rb
+++ b/lib/bullet/stack_trace_filter.rb
@@ -5,12 +5,11 @@ module Bullet
     VENDOR_PATH = '/vendor'
 
     def caller_in_project
-      app_root = rails? ? Rails.root.to_s : Dir.pwd
-      vendor_root = app_root + VENDOR_PATH
+      vendor_root = Bullet.app_root + VENDOR_PATH
       bundler_path = Bundler.bundle_path.to_s
       select_caller_locations do |location|
         caller_path = location_as_path(location)
-        caller_path.include?(app_root) && !caller_path.include?(vendor_root) && !caller_path.include?(bundler_path) ||
+        caller_path.include?(Bullet.app_root) && !caller_path.include?(vendor_root) && !caller_path.include?(bundler_path) ||
           Bullet.stacktrace_includes.any? { |include_pattern| pattern_matches?(location, include_pattern) }
       end
     end


### PR DESCRIPTION
In one of our non-Rails projects we added ActionMailer. It comes along
with a number of dependencies and modules namespaced under `Rails`.

The problem is that we don't have a Rails app and therefore `Rails.root`
is not defined. This causes bullet to blow up when getting `Rails.root`. 

The fix is to be more specific with the check. I also consolidated the
logic to one method since `rails?` was only ever used to check if Bullet
should call `Rails.root`. A similar approach is taken in many other libraries and seems to work well: https://github.com/search?q=defined%3F%28Rails.root&type=Code