### PR TITLE
Handle unpersisted primary key values

### DIFF
--- a/lib/bullet/detector/association.rb
+++ b/lib/bullet/detector/association.rb
@@ -7,7 +7,7 @@ module Bullet
         def add_object_associations(object, associations)
           return unless Bullet.start?
           return if !Bullet.n_plus_one_query_enable? && !Bullet.unused_eager_loading_enable?
-          return unless object.primary_key_value
+          return unless object.bullet_primary_key_value
 
           Bullet.debug('Detector::Association#add_object_associations', "object: #{object.bullet_key}, associations: #{associations}")
           object_associations.add(object.bullet_key, associations)
@@ -16,7 +16,7 @@ module Bullet
         def add_call_object_associations(object, associations)
           return unless Bullet.start?
           return if !Bullet.n_plus_one_query_enable? && !Bullet.unused_eager_loading_enable?
-          return unless object.primary_key_value
+          return unless object.bullet_primary_key_value
 
           Bullet.debug('Detector::Association#add_call_object_associations', "object: #{object.bullet_key}, associations: #{associations}")
           call_object_associations.add(object.bullet_key, associations)

--- a/lib/bullet/detector/counter_cache.rb
+++ b/lib/bullet/detector/counter_cache.rb
@@ -7,7 +7,7 @@ module Bullet
         def add_counter_cache(object, associations)
           return unless Bullet.start?
           return unless Bullet.counter_cache_enable?
-          return unless object.primary_key_value
+          return unless object.bullet_primary_key_value
 
           Bullet.debug('Detector::CounterCache#add_counter_cache', "object: #{object.bullet_key}, associations: #{associations}")
           if conditions_met?(object, associations)
@@ -20,7 +20,7 @@ module Bullet
           return unless Bullet.counter_cache_enable?
 
           objects = Array(object_or_objects)
-          return if objects.map(&:primary_key_value).compact.empty?
+          return if objects.map(&:bullet_primary_key_value).compact.empty?
 
           Bullet.debug('Detector::CounterCache#add_possible_objects', "objects: #{objects.map(&:bullet_key).join(', ')}")
           objects.each { |object| possible_objects.add object.bullet_key }
@@ -29,7 +29,7 @@ module Bullet
         def add_impossible_object(object)
           return unless Bullet.start?
           return unless Bullet.counter_cache_enable?
-          return unless object.primary_key_value
+          return unless object.bullet_primary_key_value
 
           Bullet.debug('Detector::CounterCache#add_impossible_object', "object: #{object.bullet_key}")
           impossible_objects.add object.bullet_key

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -14,7 +14,7 @@ module Bullet
         def call_association(object, associations)
           return unless Bullet.start?
           return unless Bullet.n_plus_one_query_enable?
-          return unless object.primary_key_value
+          return unless object.bullet_primary_key_value
           return if inversed_objects.include?(object.bullet_key, associations)
 
           add_call_object_associations(object, associations)
@@ -31,7 +31,7 @@ module Bullet
           return unless Bullet.n_plus_one_query_enable?
 
           objects = Array(object_or_objects)
-          return if objects.map(&:primary_key_value).compact.empty?
+          return if objects.map(&:bullet_primary_key_value).compact.empty?
 
           Bullet.debug('Detector::NPlusOneQuery#add_possible_objects', "objects: #{objects.map(&:bullet_key).join(', ')}")
           objects.each { |object| possible_objects.add object.bullet_key }
@@ -40,7 +40,7 @@ module Bullet
         def add_impossible_object(object)
           return unless Bullet.start?
           return unless Bullet.n_plus_one_query_enable?
-          return unless object.primary_key_value
+          return unless object.bullet_primary_key_value
 
           Bullet.debug('Detector::NPlusOneQuery#add_impossible_object', "object: #{object.bullet_key}")
           impossible_objects.add object.bullet_key
@@ -49,7 +49,7 @@ module Bullet
         def add_inversed_object(object, association)
           return unless Bullet.start?
           return unless Bullet.n_plus_one_query_enable?
-          return unless object.primary_key_value
+          return unless object.bullet_primary_key_value
 
           Bullet.debug('Detector::NPlusOneQuery#add_inversed_object', "object: #{object.bullet_key}, association: #{association}")
           inversed_objects.add object.bullet_key, association

--- a/lib/bullet/detector/unused_eager_loading.rb
+++ b/lib/bullet/detector/unused_eager_loading.rb
@@ -27,7 +27,7 @@ module Bullet
         def add_eager_loadings(objects, associations)
           return unless Bullet.start?
           return unless Bullet.unused_eager_loading_enable?
-          return if objects.map(&:primary_key_value).compact.empty?
+          return if objects.map(&:bullet_primary_key_value).compact.empty?
 
           Bullet.debug('Detector::UnusedEagerLoading#add_eager_loadings', "objects: #{objects.map(&:bullet_key).join(', ')}, associations: #{associations}")
           bullet_keys = objects.map(&:bullet_key)

--- a/lib/bullet/ext/object.rb
+++ b/lib/bullet/ext/object.rb
@@ -6,7 +6,9 @@ class Object
   end
 
   def primary_key_value
-    if self.class.respond_to?(:primary_keys) && self.class.primary_keys
+    if respond_to?(:persisted?) && !persisted?
+      nil
+    elsif self.class.respond_to?(:primary_keys) && self.class.primary_keys
       self.class.primary_keys.map { |primary_key| send primary_key }.join(',')
     elsif self.class.respond_to?(:primary_key) && self.class.primary_key
       send self.class.primary_key

--- a/lib/bullet/ext/object.rb
+++ b/lib/bullet/ext/object.rb
@@ -2,13 +2,13 @@
 
 class Object
   def bullet_key
-    "#{self.class}:#{primary_key_value}"
+    "#{self.class}:#{bullet_primary_key_value}"
   end
 
-  def primary_key_value
-    if respond_to?(:persisted?) && !persisted?
-      nil
-    elsif self.class.respond_to?(:primary_keys) && self.class.primary_keys
+  def bullet_primary_key_value
+    return if respond_to?(:persisted?) && !persisted?
+
+    if self.class.respond_to?(:primary_keys) && self.class.primary_keys
       self.class.primary_keys.map { |primary_key| send primary_key }.join(',')
     elsif self.class.respond_to?(:primary_key) && self.class.primary_key
       send self.class.primary_key

--- a/spec/bullet/ext/object_spec.rb
+++ b/spec/bullet/ext/object_spec.rb
@@ -35,5 +35,10 @@ describe Object do
       allow(Post).to receive(:primary_keys).and_return(%i[category_id writer_id])
       expect(post.primary_key_value).to eq("#{post.category_id},#{post.writer_id}")
     end
+
+    it 'it should return nil for unpersisted records' do
+      post = Post.new(id: 123)
+      expect(post.primary_key_value).to be_nil
+    end
   end
 end

--- a/spec/bullet/ext/object_spec.rb
+++ b/spec/bullet/ext/object_spec.rb
@@ -17,28 +17,28 @@ describe Object do
     end
   end
 
-  context 'primary_key_value' do
+  context 'bullet_primary_key_value' do
     it 'should return id' do
       post = Post.first
-      expect(post.primary_key_value).to eq(post.id)
+      expect(post.bullet_primary_key_value).to eq(post.id)
     end
 
     it 'should return primary key value' do
       post = Post.first
       Post.primary_key = 'name'
-      expect(post.primary_key_value).to eq(post.name)
+      expect(post.bullet_primary_key_value).to eq(post.name)
       Post.primary_key = 'id'
     end
 
     it 'should return value for multiple primary keys' do
       post = Post.first
       allow(Post).to receive(:primary_keys).and_return(%i[category_id writer_id])
-      expect(post.primary_key_value).to eq("#{post.category_id},#{post.writer_id}")
+      expect(post.bullet_primary_key_value).to eq("#{post.category_id},#{post.writer_id}")
     end
 
     it 'it should return nil for unpersisted records' do
       post = Post.new(id: 123)
-      expect(post.primary_key_value).to be_nil
+      expect(post.bullet_primary_key_value).to be_nil
     end
   end
 end


### PR DESCRIPTION
Two changes here:

1. I renamed `Object#primary_key_value` to `Object#bullet_primary_key_value` to make it clear that this core extension is specific to `bullet` and to avoid potential naming conflicts. (This feels at least to me like a semi-private method that shouldn't be used by external code...)
2. I added a test case and made code modifications to handle the case when a primary key value has been manually set on an unpersisted record. One might commonly do this, for instance, in a test context (to avoid making unnecessary database round-trips).

Here's a very contrived example:

```ruby
# Totally make-believe test case:

post = user.posts.build(id: 123)
comment = post.comments.build(text: 'hey, cool post')
email = WeeklySummaryEmail.new(user: user)

expect(email.subject).to eq "1 new comment on post 123!"
# `email.subject` has code to traverse user->posts->comments
```

Previously, bullet would prevent this test case from passing, even though the model does not get persisted at all, simply because the `id` value is present. This change allows bullet to additionally rely on `persisted?` (if it is defined) to decide whether a record might be subject to N+1 issues, etc.