### PR TITLE
Fix release date of 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next Release
 
-## 6.0.0 (02/22/2019)
+## 6.0.0 (04/25/2019)
 
 * Add XHR support to Bullet
 * Support Rails 6.0


### PR DESCRIPTION
I'm not sure this is correct, but according to rubygems, it seems 6.0 released in April. 
https://rubygems.org/gems/bullet/versions/6.0.0 

If you intend to do this in February, please close this. Thanks!
