### PR TITLE
fix syntax error

### DIFF
--- a/lib/bullet/bullet_xhr.js
+++ b/lib/bullet/bullet_xhr.js
@@ -15,7 +15,7 @@
   function newOnload() {
     if (
       this._storedUrl.startsWith(
-        window.location.protocol + '//' + window.location.host,
+        window.location.protocol + '//' + window.location.host
       ) ||
       !this._storedUrl.startsWith('http') // For relative paths
     ) {


### PR DESCRIPTION
I found the error on IE11, but Chrome ignores it 🤔.