### PR TITLE
Auto corrected by following Lint Ruby Layout/TrailingWhitespace

### DIFF
--- a/lib/bullet/active_record4.rb
+++ b/lib/bullet/active_record4.rb
@@ -188,7 +188,7 @@ module Bullet
           end
           result
         end
-        
+
       end
     end
   end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Layout/TrailingWhitespace

Click [here](https://awesomecode.io/repos/flyerhzm/bullet/ruby_lint_configs/869) to configure it on awesomecode.io