### PR TITLE
Prevent "Maximum call stack exceeded" errors when used with Turbolinks

### DIFF
--- a/lib/bullet/bullet_xhr.js
+++ b/lib/bullet/bullet_xhr.js
@@ -1,18 +1,29 @@
 (function() {
   var oldOpen = window.XMLHttpRequest.prototype.open;
   var oldSend = window.XMLHttpRequest.prototype.send;
-  function newOpen(method, url, async, user, password) {
+
+  /**
+   * Return early if we've already extended prototype. This prevents
+   * "maximum call stack exceeded" errors when used with Turbolinks.
+   * See https://github.com/flyerhzm/bullet/issues/454
+   */
+  if (isBulletInitiated()) return;
+
+  function isBulletInitiated() {
+    return oldOpen.name == 'bulletXHROpen' && oldSend.name == 'bulletXHRSend';
+  }
+  function bulletXHROpen(_, url) {
     this._storedUrl = url;
     return oldOpen.apply(this, arguments);
   }
-  function newSend(data) {
+  function bulletXHRSend() {
     if (this.onload) {
       this._storedOnload = this.onload;
     }
-    this.addEventListener('load', newOnload);
+    this.addEventListener('load', bulletXHROnload);
     return oldSend.apply(this, arguments);
   }
-  function newOnload() {
+  function bulletXHROnload() {
     if (
       this._storedUrl.startsWith(
         window.location.protocol + '//' + window.location.host
@@ -53,6 +64,6 @@
       return this._storedOnload.apply(this, arguments);
     }
   }
-  window.XMLHttpRequest.prototype.open = newOpen;
-  window.XMLHttpRequest.prototype.send = newSend;
+  window.XMLHttpRequest.prototype.open = bulletXHROpen;
+  window.XMLHttpRequest.prototype.send = bulletXHRSend;
 })();


### PR DESCRIPTION
#### Problem
When used with Turbolinks, users are presented with _maximum call stack exceeded_ errors which prevents the pages from rendering.

#### Steps to reproduce the problem
1. Using any version of Turbolinks.
1. Navigate to a page that returns a Bullet error.
1. Navigate to another page with a Bullet error.
1. Navigate anywhere else.

#### Cause
Because Turbolinks doesn't reload the page `XMLHttpRequest.prototype.open` and `send` are not reset on page load. When we extend these functions, we keep track of the original implementation and call it at the end. If we do this twice in a row, we recursively call the same function which results in the described error.

#### Solution
Check for function names of `open` and `send`. If they've been changed to Bullet functions, return.

#### Other changes
More descriptive function names and removal of unused arguments.

Closes #454 