### PR TITLE
Fix Transport-Encoding: chunked template streaming

### DIFF
--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -70,7 +70,8 @@ module Bullet
     end
 
     def sse?(headers)
-      headers['Content-Type'] == 'text/event-stream'
+      # Using `ActionController::Live` or `render stream: true`
+      headers['Content-Type'] == 'text/event-stream' || headers['Transfer-Encoding'] == 'chunked'
     end
 
     def html_request?(headers, response)

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -39,6 +39,32 @@ module Bullet
       end
     end
 
+    context '#sse?' do
+      it 'should be true if Content-Type is text/event-stream (using `ActionController::Live`)' do
+        headers = { 'Content-Type' => 'text/event-stream' }
+        response = double(body: '<html><head></head><body></body></html>')
+        expect(middleware).to be_sse(headers)
+      end
+
+      it 'should be true if Transfer-Encoding is chunked (using `render stream: true`)' do
+        headers = { 'Transfer-Encoding' => 'chunked' }
+        response = double(body: '<html><head></head><body></body></html>')
+        expect(middleware).to be_sse(headers)
+      end
+
+      it 'should be false if the headers are anything else' do
+        headers = { 'Content-Type' => 'text/html', 'Transfer-Encoding' => 'deflate' }
+        response = double(body: '<html><head></head><body></body></html>')
+        expect(middleware).not_to be_sse(headers)
+      end
+
+      it 'should be false if the headers are not present' do
+        headers = {}
+        response = double(body: '<html><head></head><body></body></html>')
+        expect(middleware).not_to be_sse(headers)
+      end
+    end
+
     context 'empty?' do
       it 'should be false if response is a string and not empty' do
         response = double(body: '<html><head></head><body></body></html>')


### PR DESCRIPTION
Using chunked template streaming in Rails via `render stream: true` doesn't work with Bullet. Much like with the [server sent events issue](https://github.com/flyerhzm/bullet/issues/212) when using (`ActionController::Live`) you can't mess with the stream this way. 

I've added an easy fix, checking the header.

I've also added tests for the existing `sse?` method which I amended. 