### PR TITLE
Use modern includes syntax in warnings

### DIFF
--- a/lib/bullet/notification/base.rb
+++ b/lib/bullet/notification/base.rb
@@ -73,7 +73,7 @@ module Bullet
       end
 
       def associations_str
-        ":includes => #{@associations.map { |a| a.to_s.to_sym unless a.is_a? Hash }.inspect}"
+        ".includes(#{@associations.map { |a| a.to_s.to_sym }.inspect})"
       end
     end
   end

--- a/lib/bullet/notification/n_plus_one_query.rb
+++ b/lib/bullet/notification/n_plus_one_query.rb
@@ -10,7 +10,7 @@ module Bullet
       end
 
       def body
-        "#{klazz_associations_str}\n  Add to your finder: #{associations_str}"
+        "#{klazz_associations_str}\n  Add to your query: #{associations_str}"
       end
 
       def title

--- a/lib/bullet/notification/unused_eager_loading.rb
+++ b/lib/bullet/notification/unused_eager_loading.rb
@@ -10,7 +10,7 @@ module Bullet
       end
 
       def body
-        "#{klazz_associations_str}\n  Remove from your finder: #{associations_str}"
+        "#{klazz_associations_str}\n  Remove from your query: #{associations_str}"
       end
 
       def title

--- a/spec/bullet/notification/n_plus_one_query_spec.rb
+++ b/spec/bullet/notification/n_plus_one_query_spec.rb
@@ -9,20 +9,20 @@ module Bullet
 
       it do
         expect(subject.body_with_caller).to eq(
-          "  Post => [:comments, :votes]\n  Add to your finder: :includes => [:comments, :votes]\nCall stack\n  caller1\n  caller2\n"
+          "  Post => [:comments, :votes]\n  Add to your query: .includes([:comments, :votes])\nCall stack\n  caller1\n  caller2\n"
         )
       end
       it do
         expect([subject.body_with_caller, subject.body_with_caller]).to eq(
           [
-            "  Post => [:comments, :votes]\n  Add to your finder: :includes => [:comments, :votes]\nCall stack\n  caller1\n  caller2\n",
-            "  Post => [:comments, :votes]\n  Add to your finder: :includes => [:comments, :votes]\nCall stack\n  caller1\n  caller2\n"
+            "  Post => [:comments, :votes]\n  Add to your query: .includes([:comments, :votes])\nCall stack\n  caller1\n  caller2\n",
+            "  Post => [:comments, :votes]\n  Add to your query: .includes([:comments, :votes])\nCall stack\n  caller1\n  caller2\n"
           ]
         )
       end
       it do
         expect(subject.body).to eq(
-          "  Post => [:comments, :votes]\n  Add to your finder: :includes => [:comments, :votes]"
+          "  Post => [:comments, :votes]\n  Add to your query: .includes([:comments, :votes])"
         )
       end
       it { expect(subject.title).to eq('USE eager loading in path') }

--- a/spec/bullet/notification/unused_eager_loading_spec.rb
+++ b/spec/bullet/notification/unused_eager_loading_spec.rb
@@ -9,7 +9,7 @@ module Bullet
 
       it do
         expect(subject.body).to eq(
-          "  Post => [:comments, :votes]\n  Remove from your finder: :includes => [:comments, :votes]"
+          "  Post => [:comments, :votes]\n  Remove from your query: .includes([:comments, :votes])"
         )
       end
       it { expect(subject.title).to eq('AVOID eager loading in path') }


### PR DESCRIPTION
Current warning uses old `:include => []` syntax which does not work in Rails, not 100% on Mongoid but I do know it supports `.includes()`.

