### PR TITLE
warning: The last argument is used as the keyword parameter

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -41,8 +41,8 @@ module Bullet
     attr_accessor :add_footer, :orm_pathches_applied
 
     available_notifiers = UniformNotifier::AVAILABLE_NOTIFIERS.map { |notifier| "#{notifier}=" }
-    available_notifiers << { to: UniformNotifier }
-    delegate(*available_notifiers)
+    available_notifiers_options = { to: UniformNotifier }
+    delegate(*available_notifiers, **available_notifiers_options)
 
     def raise=(should_raise)
       UniformNotifier.raise = (should_raise ? Notification::UnoptimizedQueryError : false)


### PR DESCRIPTION
I have just install ruby-2.7.0-preview3 and see the warning in the console
`warning: The last argument is used as the keyword parameter`
.rbenv/versions/2.7.0-preview3/lib/ruby/gems/2.7.0/gems/bullet-6.0.2/lib/bullet.rb:42: warning: The last argument is used as the keyword parameter
this PR fixes warning