### PR TITLE
Add `skip_html_injection` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* Add skip_html_injection flag
+
 ## 6.0.2 (08/20/2019)
 
 * Fully support Rails 6.0

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ config.after_initialize do
   Bullet.airbrake = true
   Bullet.rollbar = true
   Bullet.add_footer = true
+  Bullet.skip_html_injection = false
   Bullet.stacktrace_includes = [ 'your_gem', 'your_middleware' ]
   Bullet.stacktrace_excludes = [ 'their_gem', 'their_middleware', ['my_file.rb', 'my_method'], ['my_file.rb', 16..20] ]
   Bullet.slack = { webhook_url: 'http://some.slack.url', channel: '#default', username: 'notifier' }
@@ -85,6 +86,7 @@ The code above will enable all of the Bullet notification systems:
 * `Bullet.rollbar`: add notifications to rollbar
 * `Bullet.sentry`: add notifications to sentry
 * `Bullet.add_footer`: adds the details in the bottom left corner of the page. Double click the footer or use close button to hide footer.
+* `Bullet.skip_html_injection`: prevents Bullet from injecting XHR into the returned HTML. This must be false for receiving alerts or console logging.
 * `Bullet.stacktrace_includes`: include paths with any of these substrings in the stack trace, even if they are not in your main app
 * `Bullet.stacktrace_excludes`: ignore paths with any of these substrings in the stack trace, even if they are not in your main app.
    Each item can be a string (match substring), a regex, or an array where the first item is a path to match, and the second

--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -36,7 +36,8 @@ module Bullet
                 :unused_eager_loading_enable,
                 :counter_cache_enable,
                 :stacktrace_includes,
-                :stacktrace_excludes
+                :stacktrace_excludes,
+                :skip_html_injection
     attr_reader :whitelist
     attr_accessor :add_footer, :orm_pathches_applied
 
@@ -237,6 +238,10 @@ module Bullet
 
     def console_enabled?
       UniformNotifier.active_notifiers.include?(UniformNotifier::JavascriptConsole)
+    end
+
+    def skip_html_injection?
+      @skip_html_injection || false
     end
 
     private

--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -17,7 +17,7 @@ module Bullet
       response_body = nil
 
       if Bullet.notification?
-        if !file?(headers) && !sse?(headers) && !empty?(response) && status == 200
+        if !Bullet.skip_html_injection? && !file?(headers) && !sse?(headers) && !empty?(response) && status == 200
           if html_request?(headers, response)
             response_body = response_body(response)
             response_body = append_to_html_body(response_body, footer_note) if Bullet.add_footer


### PR DESCRIPTION
The reason that I am opening this PR is because we would
like to have bullet running in certain environments to log
to the standard Rails logger without having it enabled at
all in the UI. We also have a strict CSP and do not wish
to open it up for Bullet since we do not need these features.