### PR TITLE
Fix empty? when a response does not have body

### DIFF
--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -40,6 +40,7 @@ module Bullet
     def empty?(response)
       # response may be ["Not Found"], ["Move Permanently"], etc, but
       # those should not happen if the status is 200
+      return true if !response.respond_to?(:body) && !response.respond_to?(:first)
       body = response_body(response)
       body.nil? || body.empty?
     end

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -54,6 +54,11 @@ module Bullet
         response = double(body: '')
         expect(middleware).to be_empty(response)
       end
+
+      it 'should be true if no response body' do
+        response = double()
+        expect(middleware).to be_empty(response)
+      end
     end
 
     context '#call' do


### PR DESCRIPTION
Fix empty? method condition when a response does not respond to **body**
This fix is related to a [question](https://github.com/flexport/bullet/pull/1#discussion_r363533973) in this feature  #436 https://github.com/flyerhzm/bullet/pull/436/files#diff-aba60c0c33aae80c889d4808092bb153L34
