### PR TITLE
Don't modify response body if not using relevant notifiers

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -240,8 +240,8 @@ module Bullet
       UniformNotifier.active_notifiers.include?(UniformNotifier::JavascriptConsole)
     end
 
-    def skip_html_injection?
-      @skip_html_injection || false
+    def inject_into_page?
+      !@skip_html_injection && (console_enabled? || add_footer)
     end
 
     private

--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -17,7 +17,7 @@ module Bullet
       response_body = nil
 
       if Bullet.notification?
-        if !Bullet.skip_html_injection? && !file?(headers) && !sse?(headers) && !empty?(response) && status == 200
+        if Bullet.inject_into_page? && !file?(headers) && !sse?(headers) && !empty?(response) && status == 200
           if html_request?(headers, response)
             response_body = response_body(response)
             response_body = append_to_html_body(response_body, footer_note) if Bullet.add_footer


### PR DESCRIPTION
We've got a similar usecase as https://github.com/flyerhzm/bullet/pull/484 where we're just using the logging notifiers.

Debugging the issue I ran into the newly added `skip_html_injection` flag, however I think we can go further than that, bullet has enough information to know whether we want the HTML injections or not, so this PR adds logic to only add the HTML/XHR info if one of the notifiers that relies on it is enabled.

This probably negates the usecase of that flag, but I haven't removed it in this PR.

