### PR TITLE
Fixed spaces around settings

### DIFF
--- a/lib/generators/bullet/install_generator.rb
+++ b/lib/generators/bullet/install_generator.rb
@@ -28,20 +28,20 @@ module Bullet
       end
 
       def enable_in_test
-        if yes?('Would you like to enable bullet in test environment? (y/n)')
-          environment(nil, env: 'test') do
-            <<~FILE
-              config.after_initialize do
-                Bullet.enable        = true
-                Bullet.bullet_logger = true
-                Bullet.raise         = true # raise an error if n+1 query occurs
-              end
+        return unless yes?('Would you like to enable bullet in test environment? (y/n)')
 
-            FILE
-          end
+        environment(nil, env: 'test') do
+          <<~FILE
+            config.after_initialize do
+              Bullet.enable        = true
+              Bullet.bullet_logger = true
+              Bullet.raise         = true # raise an error if n+1 query occurs
+            end
 
-          say 'Enabled bullet in config/environments/test.rb'
+          FILE
         end
+
+        say 'Enabled bullet in config/environments/test.rb'
       end
     end
   end

--- a/lib/generators/bullet/install_generator.rb
+++ b/lib/generators/bullet/install_generator.rb
@@ -10,19 +10,18 @@ module Bullet
 
       def enable_in_development
         environment(nil, env: 'development') do
-          <<-"FILE"
+          <<~FILE
+            config.after_initialize do
+              Bullet.enable        = true
+              Bullet.alert         = true
+              Bullet.bullet_logger = true
+              Bullet.console       = true
+            # Bullet.growl         = true
+              Bullet.rails_logger  = true
+              Bullet.add_footer    = true
+            end
 
-  config.after_initialize do
-    Bullet.enable        = true
-    Bullet.alert         = true
-    Bullet.bullet_logger = true
-    Bullet.console       = true
-  # Bullet.growl         = true
-    Bullet.rails_logger  = true
-    Bullet.add_footer    = true
-  end
           FILE
-            .strip
         end
 
         say 'Enabled bullet in config/environments/development.rb'
@@ -31,15 +30,14 @@ module Bullet
       def enable_in_test
         if yes?('Would you like to enable bullet in test environment? (y/n)')
           environment(nil, env: 'test') do
-            <<-"FILE"
+            <<~FILE
+              config.after_initialize do
+                Bullet.enable        = true
+                Bullet.bullet_logger = true
+                Bullet.raise         = true # raise an error if n+1 query occurs
+              end
 
-  config.after_initialize do
-    Bullet.enable        = true
-    Bullet.bullet_logger = true
-    Bullet.raise         = true # raise an error if n+1 query occurs
-  end
             FILE
-              .strip
           end
 
           say 'Enabled bullet in config/environments/test.rb'


### PR DESCRIPTION
I am not good at English, so please understand that the sentence may be strange...
Also, since this is the first time that you have posted a PR to a human repository, please point out if the procedure is wrong.

```
bundle exec rails g bullet:install
```

When the enable `bullet` using the above command, the settings will be added to environment files like:

```ruby
# config/environments/development.rb

Rails.application.configure do
  config.after_initialize do
      Bullet.enable        = true
      Bullet.alert         = true
      Bullet.bullet_logger = true
      Bullet.console       = true
    # Bullet.growl         = true
      Bullet.rails_logger  = true
      Bullet.add_footer    = true
    end  # Settings specified here will take precedence over those in config/application.rb.

# ...
```

```ruby
# config/environments/test.rb

Rails.application.configure do
  config.after_initialize do
      Bullet.enable        = true
      Bullet.bullet_logger = true
      Bullet.raise         = true # raise an error if n+1 query occurs
    end  # Settings specified here will take precedence over those in config/application.rb.

# ...
```

I had the stress of manually correcting these indentation gaps every time.
So, I fixed these to add with correct indentation like:

```ruby
# config/environments/development.rb

Rails.application.configure do
  config.after_initialize do
    Bullet.enable        = true
    Bullet.alert         = true
    Bullet.bullet_logger = true
    Bullet.console       = true
  # Bullet.growl         = true
    Bullet.rails_logger  = true
    Bullet.add_footer    = true
  end

  # Settings specified here will take precedence over those in config/application.rb.

# ...
```

```ruby
# config/environments/test.rb

Rails.application.configure do
  config.after_initialize do
    Bullet.enable        = true
    Bullet.bullet_logger = true
    Bullet.raise         = true # raise an error if n+1 query occurs
  end

  # Settings specified here will take precedence over those in config/application.rb.

# ...
```

Please check when you have time.