### PR TITLE
Rename whitelist to safelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,15 +111,15 @@ Bullet.unused_eager_loading_enable = false
 Bullet.counter_cache_enable        = false
 ```
 
-## Whitelist
+## Safe list
 
 Sometimes Bullet may notify you of query problems you don't care to fix, or
-which come from outside your code. You can whitelist these to ignore them:
+which come from outside your code. You can add them to a safe list to ignore them:
 
 ```ruby
-Bullet.add_whitelist :type => :n_plus_one_query, :class_name => "Post", :association => :comments
-Bullet.add_whitelist :type => :unused_eager_loading, :class_name => "Post", :association => :comments
-Bullet.add_whitelist :type => :counter_cache, :class_name => "Country", :association => :cities
+Bullet.add_safelist :type => :n_plus_one_query, :class_name => "Post", :association => :comments
+Bullet.add_safelist :type => :unused_eager_loading, :class_name => "Post", :association => :comments
+Bullet.add_safelist :type => :counter_cache, :class_name => "Country", :association => :cities
 ```
 
 If you want to skip bullet in some specific controller actions, you can

--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -135,7 +135,7 @@ module Bullet
         WARN
       )
 
-      delete_safelist
+      delete_safelist(options)
     end
 
     def get_whitelist_associations(type, class_name)

--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -58,7 +58,7 @@ module Bullet
       @enable = @n_plus_one_query_enable = @unused_eager_loading_enable = @counter_cache_enable = enable
 
       if enable?
-        reset_whitelist
+        reset_safelist
         unless orm_patches_applied
           self.orm_patches_applied = true
           Bullet::Mongoid.enable if mongoid?
@@ -95,29 +95,74 @@ module Bullet
       @stacktrace_excludes || []
     end
 
+    def add_safelist(options)
+      reset_safelist
+      Thread.current[:safelist][options[:type]][options[:class_name]] ||= []
+      Thread.current[:safelist][options[:type]][options[:class_name]] << options[:association].to_sym
+    end
+
+    def delete_safelist(options)
+      reset_safelist
+      Thread.current[:safelist][options[:type]][options[:class_name]] ||= []
+      Thread.current[:safelist][options[:type]][options[:class_name]].delete(options[:association].to_sym)
+      Thread.current[:safelist][options[:type]].delete_if { |_key, val| val.empty? }
+    end
+
+    def get_safelist_associations(type, class_name)
+      Array(Thread.current[:safelist][type][class_name])
+    end
+
+    def reset_safelist
+      Thread.current[:safelist] ||= { n_plus_one_query: {}, unused_eager_loading: {}, counter_cache: {} }
+    end
+
+    def clear_safelist
+      Thread.current[:safelist] = nil
+    end
+
     def add_whitelist(options)
-      reset_whitelist
-      Thread.current[:whitelist][options[:type]][options[:class_name]] ||= []
-      Thread.current[:whitelist][options[:type]][options[:class_name]] << options[:association].to_sym
+      ActiveSupport::Deprecation.warn(<<~WARN.strip
+        add_whitelist is deprecated in favor of add_safelist. It will be removed from the next major release.
+        WARN
+      )
+
+      add_safelist(options)
     end
 
     def delete_whitelist(options)
-      reset_whitelist
-      Thread.current[:whitelist][options[:type]][options[:class_name]] ||= []
-      Thread.current[:whitelist][options[:type]][options[:class_name]].delete(options[:association].to_sym)
-      Thread.current[:whitelist][options[:type]].delete_if { |_key, val| val.empty? }
+      ActiveSupport::Deprecation.warn(<<~WARN.strip
+        delete_whitelist is deprecated in favor of delete_safelist. It will be removed from the next major release.
+        WARN
+      )
+
+      delete_safelist
     end
 
     def get_whitelist_associations(type, class_name)
-      Array(Thread.current[:whitelist][type][class_name])
+      ActiveSupport::Deprecation.warn(<<~WARN.strip
+        get_whitelist_associations is deprecated in favor of get_safelist_associations. It will be removed from the next major release.
+        WARN
+      )
+
+      get_safelist_associations(type, class_name)
     end
 
     def reset_whitelist
-      Thread.current[:whitelist] ||= { n_plus_one_query: {}, unused_eager_loading: {}, counter_cache: {} }
+      ActiveSupport::Deprecation.warn(<<~WARN.strip
+        reset_whitelist is deprecated in favor of reset_safelist. It will be removed from the next major release.
+        WARN
+      )
+
+      reset_safelist
     end
 
     def clear_whitelist
-      Thread.current[:whitelist] = nil
+      ActiveSupport::Deprecation.warn(<<~WARN.strip
+        clear_whitelist is deprecated in favor of clear_safelist. It will be removed from the next major release.
+        WARN
+      )
+
+      clear_safelist
     end
 
     def bullet_logger=(active)

--- a/lib/bullet/detector/counter_cache.rb
+++ b/lib/bullet/detector/counter_cache.rb
@@ -54,7 +54,7 @@ module Bullet
         private
 
         def create_notification(klazz, associations)
-          notify_associations = Array(associations) - Bullet.get_whitelist_associations(:counter_cache, klazz)
+          notify_associations = Array(associations) - Bullet.get_safelist_associations(:counter_cache, klazz)
 
           if notify_associations.present?
             notice = Bullet::Notification::CounterCache.new klazz, notify_associations

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -95,7 +95,7 @@ module Bullet
         private
 
         def create_notification(callers, klazz, associations)
-          notify_associations = Array(associations) - Bullet.get_whitelist_associations(:n_plus_one_query, klazz)
+          notify_associations = Array(associations) - Bullet.get_safelist_associations(:n_plus_one_query, klazz)
 
           if notify_associations.present?
             notice = Bullet::Notification::NPlusOneQuery.new(callers, klazz, notify_associations)

--- a/lib/bullet/detector/unused_eager_loading.rb
+++ b/lib/bullet/detector/unused_eager_loading.rb
@@ -65,7 +65,7 @@ module Bullet
         private
 
         def create_notification(callers, klazz, associations)
-          notify_associations = Array(associations) - Bullet.get_whitelist_associations(:unused_eager_loading, klazz)
+          notify_associations = Array(associations) - Bullet.get_safelist_associations(:unused_eager_loading, klazz)
 
           if notify_associations.present?
             notice = Bullet::Notification::UnusedEagerLoading.new(callers, klazz, notify_associations)

--- a/spec/bullet_spec.rb
+++ b/spec/bullet_spec.rb
@@ -74,31 +74,60 @@ describe Bullet, focused: true do
     end
   end
 
+  describe '#add_safelist' do
+    context "for 'special' class names" do
+      it 'is added to the safelist successfully' do
+        Bullet.add_safelist(type: :n_plus_one_query, class_name: 'Klass', association: :department)
+        expect(Bullet.get_safelist_associations(:n_plus_one_query, 'Klass')).to include :department
+      end
+    end
+  end
+
   describe '#add_whitelist' do
     context "for 'special' class names" do
-      it 'is added to the whitelist successfully' do
+      it 'is added to the safelist successfully' do
         Bullet.add_whitelist(type: :n_plus_one_query, class_name: 'Klass', association: :department)
-        expect(Bullet.get_whitelist_associations(:n_plus_one_query, 'Klass')).to include :department
+        expect(Bullet.get_safelist_associations(:n_plus_one_query, 'Klass')).to include :department
+      end
+    end
+  end
+
+  describe '#delete_safelist' do
+    context "for 'special' class names" do
+      it 'is deleted from the safelist successfully' do
+        Bullet.add_safelist(type: :n_plus_one_query, class_name: 'Klass', association: :department)
+        Bullet.delete_safelist(type: :n_plus_one_query, class_name: 'Klass', association: :department)
+        expect(Thread.current[:safelist][:n_plus_one_query]).to eq({})
+      end
+    end
+
+    context 'when exists multiple definitions' do
+      it 'is deleted from the safelist successfully' do
+        Bullet.add_safelist(type: :n_plus_one_query, class_name: 'Klass', association: :department)
+        Bullet.add_safelist(type: :n_plus_one_query, class_name: 'Klass', association: :team)
+        Bullet.delete_safelist(type: :n_plus_one_query, class_name: 'Klass', association: :team)
+        expect(Bullet.get_safelist_associations(:n_plus_one_query, 'Klass')).to include :department
+        expect(Bullet.get_safelist_associations(:n_plus_one_query, 'Klass')).to_not include :team
       end
     end
   end
 
   describe '#delete_whitelist' do
     context "for 'special' class names" do
-      it 'is deleted from the whitelist successfully' do
-        Bullet.add_whitelist(type: :n_plus_one_query, class_name: 'Klass', association: :department)
+      it 'is deleted from the safelist successfully' do
+        Bullet.add_safelist(type: :n_plus_one_query, class_name: 'Klass', association: :department)
         Bullet.delete_whitelist(type: :n_plus_one_query, class_name: 'Klass', association: :department)
-        expect(Thread.current[:whitelist][:n_plus_one_query]).to eq({})
+        expect(Thread.current[:safelist][:n_plus_one_query]).to eq({})
       end
     end
 
     context 'when exists multiple definitions' do
-      it 'is deleted from the whitelist successfully' do
-        Bullet.add_whitelist(type: :n_plus_one_query, class_name: 'Klass', association: :department)
-        Bullet.add_whitelist(type: :n_plus_one_query, class_name: 'Klass', association: :team)
+      it 'is deleted from the safelist successfully' do
+        Bullet.add_safelist(type: :n_plus_one_query, class_name: 'Klass', association: :department)
+        Bullet.add_safelist(type: :n_plus_one_query, class_name: 'Klass', association: :team)
         Bullet.delete_whitelist(type: :n_plus_one_query, class_name: 'Klass', association: :team)
-        expect(Bullet.get_whitelist_associations(:n_plus_one_query, 'Klass')).to include :department
-        expect(Bullet.get_whitelist_associations(:n_plus_one_query, 'Klass')).to_not include :team
+        expect(Bullet.get_safelist_associations(:n_plus_one_query, 'Klass')).to include :department
+        expect(Bullet.get_safelist_associations(:n_plus_one_query, 'Klass')).to_not include :team
       end
     end
   end

--- a/spec/integration/active_record/association_spec.rb
+++ b/spec/integration/active_record/association_spec.rb
@@ -693,9 +693,9 @@ if active_record?
       end
     end
 
-    context 'whitelist n plus one query' do
-      before { Bullet.add_whitelist type: :n_plus_one_query, class_name: 'Post', association: :comments }
-      after { Bullet.clear_whitelist }
+    context 'add n plus one query to safelist' do
+      before { Bullet.add_safelist type: :n_plus_one_query, class_name: 'Post', association: :comments }
+      after { Bullet.clear_safelist }
 
       it 'should not detect n plus one query' do
         Post.all.each { |post| post.comments.map(&:name) }
@@ -714,9 +714,9 @@ if active_record?
       end
     end
 
-    context 'whitelist unused eager loading' do
-      before { Bullet.add_whitelist type: :unused_eager_loading, class_name: 'Post', association: :comments }
-      after { Bullet.clear_whitelist }
+    context 'add unused eager loading to safelist' do
+      before { Bullet.add_safelist type: :unused_eager_loading, class_name: 'Post', association: :comments }
+      after { Bullet.clear_safelist }
 
       it 'should not detect unused eager loading' do
         Post.includes(:comments).map(&:name)

--- a/spec/integration/counter_cache_spec.rb
+++ b/spec/integration/counter_cache_spec.rb
@@ -55,9 +55,9 @@ if !mongoid? && active_record?
       end
     end
 
-    context 'whitelist' do
-      before { Bullet.add_whitelist type: :counter_cache, class_name: 'Country', association: :cities }
-      after { Bullet.clear_whitelist }
+    context 'safelist' do
+      before { Bullet.add_safelist type: :counter_cache, class_name: 'Country', association: :cities }
+      after { Bullet.clear_safelist }
 
       it 'should not detect counter cache' do
         Country.all.each { |country| country.cities.size }


### PR DESCRIPTION
Renames instances of `whitelist` to `safelist` and adds deprecation messages for the previous methods.

See https://github.com/flyerhzm/bullet/issues/510