### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ or add it into a Gemfile (Bundler):
 gem 'bullet', group: 'development'
 ```
 
+enable the Bullet gem with generate command
+
+```ruby
+bundle exec rails g bullet:install
+```
+The generate command will auto generate the default configuration and may ask to include in the test environment as well. See below for custom configuration.
+
 **Note**: make sure `bullet` gem is added after activerecord (rails) and
 mongoid.
 


### PR DESCRIPTION
So I realized in the `Readme` you have to get all the way to the bottom to find the demo section to see that you can generate a configuration with default config. 

Moving it up a bit would be helpful for people like me who tried to figure it out for a few minutes.