### PR TITLE
Fix to render bullet notification as html safe string

### DIFF
--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -46,6 +46,7 @@ module Bullet
 
     def append_to_html_body(response_body, content)
       body = response_body.dup
+      content = content.html_safe if content.respond_to?(:html_safe)
       if body.include?('</body>')
         position = body.rindex('</body>')
         body.insert(position, content)

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -105,8 +105,30 @@ module Bullet
             expect(response.first).to include('<bullet></bullet><')
           end
 
+          it 'should change response body for html safe string if add_footer is true' do
+            expect(Bullet).to receive(:add_footer).twice.and_return(true)
+            app.response = Support::ResponseDouble.new.tap do |response|
+              response.body = ActiveSupport::SafeBuffer.new('<html><head></head><body></body></html>')
+            end
+            _, headers, response = middleware.call('Content-Type' => 'text/html')
+
+            expect(headers['Content-Length']).to eq((56 + middleware.send(:footer_note).length).to_s)
+            expect(response.first).to start_with('<html><head></head><body>')
+            expect(response.first).to include('<bullet></bullet><')
+          end
+
           it 'should change response body if console_enabled is true' do
             expect(Bullet).to receive(:console_enabled?).and_return(true)
+            _, headers, response = middleware.call('Content-Type' => 'text/html')
+            expect(headers['Content-Length']).to eq('56')
+            expect(response).to eq(%w[<html><head></head><body><bullet></bullet></body></html>])
+          end
+
+          it 'should change response body for html safe string if console_enabled is true' do
+            expect(Bullet).to receive(:console_enabled?).and_return(true)
+            app.response = Support::ResponseDouble.new.tap do |response|
+              response.body = ActiveSupport::SafeBuffer.new('<html><head></head><body></body></html>')
+            end
             _, headers, response = middleware.call('Content-Type' => 'text/html')
             expect(headers['Content-Length']).to eq('56')
             expect(response).to eq(%w[<html><head></head><body><bullet></bullet></body></html>])


### PR DESCRIPTION
In Rails 6, the spec of `ActiveSupport::SafeBuffer#insert` has been changed.
Previously, it behaves like just String, but now `ActiveSupport::SafeBuffer` exactly.
See for details: https://github.com/rails/rails/pull/33990

This change breaks bullet notification in HTML.

## Example
In Rails 5.2.
``` ruby
"".html_safe.insert 0, '<a>hi</a>' #=> '<a>hi</a>'
```

In Rails 6.
``` ruby
"".html_safe.insert 0, '<a>hi</a>'  #=> "&lt;a&gt;hi&lt;/a&gt;"
```

## Related Issues
Close https://github.com/flyerhzm/bullet/issues/488, https://github.com/flyerhzm/bullet/issues/513