### PR TITLE
Follow up thread safe whitelist

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -109,6 +109,7 @@ module Bullet
     end
 
     def get_whitelist_associations(type, class_name)
+      reset_whitelist
       Array(Thread.current[:whitelist][type][class_name])
     end
 


### PR DESCRIPTION
This PR follows up 9cda9c224a46786ecfa894480c4dd4d304db2adb.
It breaks bullet on Puma + Rails 6.

In config/environemts/development.rb, Bullet is initialized in main thread,
but each request is processed another thread.
So, each request will access to uninitialized thread variable.

Close https://github.com/flyerhzm/bullet/issues/517.