### PR TITLE
Removing arrow functions from bullet_xhr.js

### DIFF
--- a/lib/bullet/bullet_xhr.js
+++ b/lib/bullet/bullet_xhr.js
@@ -30,7 +30,7 @@
     ) {
       var bulletFooterText = this.getResponseHeader("X-bullet-footer-text");
       if (bulletFooterText) {
-        setTimeout(() => {
+        setTimeout(function() {
           var oldHtml = document.querySelector("#bullet-footer").innerHTML.split("<br>");
           var header = oldHtml[0];
           oldHtml = oldHtml.slice(1, oldHtml.length);
@@ -41,7 +41,7 @@
       }
       var bulletConsoleText = this.getResponseHeader("X-bullet-console-text");
       if (bulletConsoleText && typeof console !== "undefined" && console.log) {
-        setTimeout(() => {
+        setTimeout(function() {
           JSON.parse(bulletConsoleText).forEach((message) => {
             if (console.groupCollapsed && console.groupEnd) {
               console.groupCollapsed("Uniform Notifier");


### PR DESCRIPTION
These add no benefit to the code and make it incompatible with IE <= 11.

Using simple functions work just as well and make it work in a broader set of browsers.