### PR TITLE
Refine core extension definitions not to leak outside of Bullet

### DIFF
--- a/lib/bullet/detector/association.rb
+++ b/lib/bullet/detector/association.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using Bullet::Ext
+
 module Bullet
   module Detector
     class Association < Base

--- a/lib/bullet/detector/counter_cache.rb
+++ b/lib/bullet/detector/counter_cache.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using Bullet::Ext
+
 module Bullet
   module Detector
     class CounterCache < Base

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using Bullet::Ext
+
 module Bullet
   module Detector
     class NPlusOneQuery < Association

--- a/lib/bullet/detector/unused_eager_loading.rb
+++ b/lib/bullet/detector/unused_eager_loading.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using Bullet::Ext
+
 module Bullet
   module Detector
     class UnusedEagerLoading < Association

--- a/lib/bullet/ext/object.rb
+++ b/lib/bullet/ext/object.rb
@@ -1,19 +1,23 @@
 # frozen_string_literal: true
 
-class Object
-  def bullet_key
-    "#{self.class}:#{bullet_primary_key_value}"
-  end
+module Bullet
+  module Ext
+    refine Object do
+      def bullet_key
+        "#{self.class}:#{bullet_primary_key_value}"
+      end
 
-  def bullet_primary_key_value
-    return if respond_to?(:persisted?) && !persisted?
+      def bullet_primary_key_value
+        return if respond_to?(:persisted?) && !persisted?
 
-    if self.class.respond_to?(:primary_keys) && self.class.primary_keys
-      self.class.primary_keys.map { |primary_key| send primary_key }.join(',')
-    elsif self.class.respond_to?(:primary_key) && self.class.primary_key
-      send self.class.primary_key
-    else
-      id
+        if self.class.respond_to?(:primary_keys) && self.class.primary_keys
+          self.class.primary_keys.map { |primary_key| send primary_key }.join(',')
+        elsif self.class.respond_to?(:primary_key) && self.class.primary_key
+          send self.class.primary_key
+        else
+          id
+        end
+      end
     end
   end
 end

--- a/lib/bullet/ext/string.rb
+++ b/lib/bullet/ext/string.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-class String
-  def bullet_class_name
-    sub(/:[^:]*?$/, '')
+module Bullet
+  module Ext
+    refine String do
+      def bullet_class_name
+        sub(/:[^:]*?$/, '')
+      end
+    end
   end
 end

--- a/lib/bullet/registry/object.rb
+++ b/lib/bullet/registry/object.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using Bullet::Ext
+
 module Bullet
   module Registry
     class Object < Base

--- a/spec/bullet/detector/association_spec.rb
+++ b/spec/bullet/detector/association_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext
+
 module Bullet
   module Detector
     describe Association do

--- a/spec/bullet/detector/counter_cache_spec.rb
+++ b/spec/bullet/detector/counter_cache_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext
+
 module Bullet
   module Detector
     describe CounterCache do

--- a/spec/bullet/detector/n_plus_one_query_spec.rb
+++ b/spec/bullet/detector/n_plus_one_query_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext
+
 module Bullet
   module Detector
     describe NPlusOneQuery do

--- a/spec/bullet/detector/unused_eager_loading_spec.rb
+++ b/spec/bullet/detector/unused_eager_loading_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext
+
 module Bullet
   module Detector
     describe UnusedEagerLoading do

--- a/spec/bullet/ext/object_spec.rb
+++ b/spec/bullet/ext/object_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext
+
 describe Object do
   context 'bullet_key' do
     it 'should return class and id composition' do

--- a/spec/bullet/ext/string_spec.rb
+++ b/spec/bullet/ext/string_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext
+
 describe String do
   context 'bullet_class_name' do
     it 'should only return class name' do

--- a/spec/bullet/registry/object_spec.rb
+++ b/spec/bullet/registry/object_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext
+
 module Bullet
   module Registry
     describe Object do

--- a/spec/support/bullet_ext.rb
+++ b/spec/support/bullet_ext.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using Bullet::Ext
+
 module Bullet
   def self.collected_notifications_of_class(notification_class)
     Bullet.notification_collector.collection.select { |notification| notification.is_a? notification_class }


### PR DESCRIPTION
While investigating my app, I found some unfamiliar `bullet_` prefixed methods on Object, which turned out to be defined here inside bullet gem only for using inside bullet gem.

I believe this is the very use case of Ruby's most underevaluated feature, Refinements.

With this patch, we're no longer seeing these gem internal methods leaking into our apps.