### PR TITLE
Respect Content-Security-Policy nonces

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ end
 
 ### Work with sinatra
 
-Configure and use `Bullet::Rack`
+Configure and use `Bullet::Rack`.
 
 ```ruby
 configure :development do
@@ -225,6 +225,8 @@ configure :development do
   use Bullet::Rack
 end
 ```
+
+If your application generates a Content-Security-Policy via a separate middleware, ensure that `Bullet::Rack` is loaded _before_ that middleware.
 
 ### Run in tests
 

--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -26,7 +26,7 @@ module Bullet
   if defined?(Rails::Railtie)
     class BulletRailtie < Rails::Railtie
       initializer 'bullet.configure_rails_initialization' do |app|
-        app.middleware.use Bullet::Rack
+        app.middleware.insert_before ActionDispatch::ContentSecurityPolicy::Middleware, Bullet::Rack
       end
     end
   end

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -124,6 +124,21 @@ module Bullet
             expect(response).to eq(%w[<html><head></head><body><bullet></bullet></body></html>])
           end
 
+          it 'should include CSP nonce in inline script if console_enabled and a CSP is applied' do
+            expect(Bullet).to receive(:console_enabled?).and_return(true)
+            allow(middleware).to receive(:xhr_script).and_call_original
+
+            nonce = "+t9/wTlgG6xbHxXYUaDNzQ=="
+            app.headers = {
+              'Content-Type' => 'text/html',
+              'Content-Security-Policy' => "default-src 'self' https:; script-src 'self' https: 'nonce-#{nonce}'",
+            }
+
+            _, headers, response = middleware.call('Content-Type' => 'text/html')
+
+            expect(headers['Content-Length']).to eq((56 + middleware.send(:xhr_script, nonce).length).to_s)
+          end
+
           it 'should change response body for html safe string if console_enabled is true' do
             expect(Bullet).to receive(:console_enabled?).and_return(true)
             app.response = Support::ResponseDouble.new.tap do |response|


### PR DESCRIPTION
At the moment, an application with a secure content policy _cannot_
use the alert or console notifiers for Bullet without using a less
secure policy in the development environment, which opens the gates
for developers to forget to secure their _other_ inline scripts, etc.,
and is just a bad practice in general.

When we generate our inline scripts (or `UniformNotifier` adds its
inline scripts to the page), we should apply the script-src nonce from
the response headers, when relevant.

Resolves https://github.com/flyerhzm/bullet/issues/478.