### PR TITLE
Auto corrected by following Lint Ruby Performance/BlockGivenWithExplicitBlock

### DIFF
--- a/lib/bullet/mongoid4x.rb
+++ b/lib/bullet/mongoid4x.rb
@@ -23,7 +23,7 @@ module Bullet
         end
 
         def each(&block)
-          return to_enum unless block_given?
+          return to_enum unless block
 
           records = []
           origin_each { |record| records << record }

--- a/lib/bullet/mongoid5x.rb
+++ b/lib/bullet/mongoid5x.rb
@@ -23,7 +23,7 @@ module Bullet
         end
 
         def each(&block)
-          return to_enum unless block_given?
+          return to_enum unless block
 
           records = []
           origin_each { |record| records << record }

--- a/lib/bullet/mongoid6x.rb
+++ b/lib/bullet/mongoid6x.rb
@@ -23,7 +23,7 @@ module Bullet
         end
 
         def each(&block)
-          return to_enum unless block_given?
+          return to_enum unless block
 
           records = []
           origin_each { |record| records << record }

--- a/lib/bullet/mongoid7x.rb
+++ b/lib/bullet/mongoid7x.rb
@@ -23,7 +23,7 @@ module Bullet
         end
 
         def each(&block)
-          return to_enum unless block_given?
+          return to_enum unless block
 
           records = []
           origin_each { |record| records << record }


### PR DESCRIPTION
Auto corrected by following Lint Ruby Performance/BlockGivenWithExplicitBlock

Click [here](https://awesomecode.io/repos/flyerhzm/bullet/lint_configs/ruby/101417) to configure it on awesomecode.io