### PR TITLE
Calculate Bullet.app_root and IS_RUBY_19(former ruby_19?) once

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -73,7 +73,7 @@ module Bullet
     end
 
     def app_root
-      (defined?(::Rails.root) ? Rails.root.to_s : Dir.pwd).to_s
+      @app_root ||= (defined?(::Rails.root) ? Rails.root.to_s : Dir.pwd).to_s
     end
 
     def n_plus_one_query_enable?

--- a/lib/bullet/stack_trace_filter.rb
+++ b/lib/bullet/stack_trace_filter.rb
@@ -3,6 +3,7 @@
 module Bullet
   module StackTraceFilter
     VENDOR_PATH = '/vendor'
+    IS_RUBY_19 = Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
 
     def caller_in_project
       vendor_root = Bullet.app_root + VENDOR_PATH
@@ -47,19 +48,15 @@ module Bullet
     end
 
     def location_as_path(location)
-      ruby_19? ? location : location.absolute_path.to_s
+      IS_RUBY_19 ? location : location.absolute_path.to_s
     end
 
     def select_caller_locations
-      if ruby_19?
+      if IS_RUBY_19
         caller.select { |caller_path| yield caller_path }
       else
         caller_locations.select { |location| yield location }
       end
-    end
-
-    def ruby_19?
-      @ruby_19 ||= Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0') 
     end
   end
 end


### PR DESCRIPTION
`Gem::Version.new` and `Gem::Version#<=>` took more than half of all the execution time of `Bullet::Detector::NPlusOneQuery.call_association`, and `Bullet.app_root` roughly 1/5 more. None of this is changed without the app restart, so it's safe to calculate them once.

Before:
<img width="1792" alt="Screenshot 2021-02-22 at 09 48 12" src="https://user-images.githubusercontent.com/2388396/108683606-e2c6dd00-7502-11eb-8b26-dd964ac43acc.png">


After:
<img width="1792" alt="Screenshot 2021-02-22 at 11 07 28" src="https://user-images.githubusercontent.com/2388396/108683421-a2fff580-7502-11eb-9f23-a19603ba5d08.png">

Backstory: I was profiling an app with N+1s in it and realized that Bullet eats a lot of time, and `Gem::Version` takes most of it. After this patch `call_association` method time changed from 1300ms to 400ms. 

Last but not least, you are doing great job with this gem, I can't count how many times it helped me. Thank you!