### PR TITLE
Make readme clearer about what `skip_html_injection`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The code above will enable all of the Bullet notification systems:
 * `Bullet.rollbar`: add notifications to rollbar
 * `Bullet.sentry`: add notifications to sentry
 * `Bullet.add_footer`: adds the details in the bottom left corner of the page. Double click the footer or use close button to hide footer.
-* `Bullet.skip_html_injection`: prevents Bullet from injecting XHR into the returned HTML. This must be false for receiving alerts or console logging.
+* `Bullet.skip_html_injection`: prevents Bullet from injecting code into the returned HTML. This must be false for receiving alerts, showing the footer or console logging.
 * `Bullet.stacktrace_includes`: include paths with any of these substrings in the stack trace, even if they are not in your main app
 * `Bullet.stacktrace_excludes`: ignore paths with any of these substrings in the stack trace, even if they are not in your main app.
    Each item can be a string (match substring), a regex, or an array where the first item is a path to match, and the second


### PR DESCRIPTION
The readme says that `skip_html_injection` prevents "XHR" from being injected into the page. That's not really what this option does - it prevents HTML from being injected (and also adds javascript to the page to intercept XHR requests).

I've tweaked the wording so it's clearer that this isn't just about XHR.