### PR TITLE
Added a "skip http headers" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* Added an option to stop adding HTTP headers to API requests
+
 ## 6.1.3 (01/21/2021)
 
 * Consider ThroughAssociation at SingularAssociation like CollectionAssociation

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The code above will enable all of the Bullet notification systems:
 * `Bullet.sentry`: add notifications to sentry
 * `Bullet.add_footer`: adds the details in the bottom left corner of the page. Double click the footer or use close button to hide footer.
 * `Bullet.skip_html_injection`: prevents Bullet from injecting code into the returned HTML. This must be false for receiving alerts, showing the footer or console logging.
+* `Bullet.skip_http_headers`: don't add headers to API requests, and remove the javascript that relies on them. Note that this prevents bullet from logging warnings to the browser console or updating the footer.
 * `Bullet.stacktrace_includes`: include paths with any of these substrings in the stack trace, even if they are not in your main app
 * `Bullet.stacktrace_excludes`: ignore paths with any of these substrings in the stack trace, even if they are not in your main app.
    Each item can be a string (match substring), a regex, or an array where the first item is a path to match, and the second

--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -39,7 +39,7 @@ module Bullet
                 :stacktrace_excludes,
                 :skip_html_injection
     attr_reader :whitelist
-    attr_accessor :add_footer, :orm_patches_applied
+    attr_accessor :add_footer, :orm_patches_applied, :skip_http_headers
 
     available_notifiers = UniformNotifier::AVAILABLE_NOTIFIERS.select { |notifier| notifier != :raise }.map { |notifier| "#{notifier}=" }
     available_notifiers_options = { to: UniformNotifier }

--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -22,9 +22,9 @@ module Bullet
             response_body = response_body(response)
             response_body = append_to_html_body(response_body, footer_note) if Bullet.add_footer
             response_body = append_to_html_body(response_body, Bullet.gather_inline_notifications)
-            response_body = append_to_html_body(response_body, xhr_script) if Bullet.add_footer
+            response_body = append_to_html_body(response_body, xhr_script) if Bullet.add_footer && !Bullet.skip_http_headers
             headers['Content-Length'] = response_body.bytesize.to_s
-          else
+          elsif !Bullet.skip_http_headers
             set_header(headers, 'X-bullet-footer-text', Bullet.footer_info.uniq) if Bullet.add_footer
             set_header(headers, 'X-bullet-console-text', Bullet.text_notifications) if Bullet.console_enabled?
           end

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -90,7 +90,7 @@ module Bullet
           before do
             expect(Bullet).to receive(:notification?).and_return(true)
             allow(Bullet).to receive(:gather_inline_notifications).and_return('<bullet></bullet>')
-            allow(middleware).to receive(:xhr_script).and_return('')
+            allow(middleware).to receive(:xhr_script).and_return('<script></script>')
             allow(middleware).to receive(:footer_note).and_return('footer')
             expect(Bullet).to receive(:perform_out_of_channel_notifications)
           end
@@ -99,9 +99,8 @@ module Bullet
             expect(Bullet).to receive(:add_footer).exactly(3).times.and_return(true)
             _, headers, response = middleware.call('Content-Type' => 'text/html')
 
-            expect(headers['Content-Length']).to eq((56 + middleware.send(:footer_note).length).to_s)
-            expect(response.first).to start_with('<html><head></head><body>')
-            expect(response.first).to include('<bullet></bullet><')
+            expect(headers['Content-Length']).to eq((73 + middleware.send(:footer_note).length).to_s)
+            expect(response).to eq(%w[<html><head></head><body>footer<bullet></bullet><script></script></body></html>])
           end
 
           it 'should change response body for html safe string if add_footer is true' do
@@ -111,9 +110,8 @@ module Bullet
             end
             _, headers, response = middleware.call('Content-Type' => 'text/html')
 
-            expect(headers['Content-Length']).to eq((56 + middleware.send(:footer_note).length).to_s)
-            expect(response.first).to start_with('<html><head></head><body>')
-            expect(response.first).to include('<bullet></bullet><')
+            expect(headers['Content-Length']).to eq((73 + middleware.send(:footer_note).length).to_s)
+            expect(response).to eq(%w[<html><head></head><body>footer<bullet></bullet><script></script></body></html>])
           end
 
           it 'should change response body if console_enabled is true' do


### PR DESCRIPTION
Right now if the console or footer options are enabled, then API requests will include extra headers for bullet. These only exist to power the XHR script that's included in HTML pages, which are irrelevant to an API request. At the moment there's no way to disable this, so I've added a new option for it. Because disabling these headers prevents the XHR javascript hooks from working, I've also made the new option prevent the XHR javascript from being added to pages.

As part of this I cleaned up a handful of related tests that test existing behaviour, so I've put those changes in a separate commit.