### PR TITLE
Auto corrected by following Lint Ruby Lint/DeprecatedConstants

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -133,7 +133,7 @@ module Bullet
     end
 
     def debug(title, message)
-      puts "[Bullet][#{title}] #{message}" if ENV[BULLET_DEBUG] == TRUE
+      puts "[Bullet][#{title}] #{message}" if ENV[BULLET_DEBUG] == true
     end
 
     def start_request


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/DeprecatedConstants

Click [here](https://awesomecode.io/repos/flyerhzm/bullet/lint_configs/ruby/106330) to configure it on awesomecode.io