### PR TITLE
Do not use `Rails.root` if it's nil

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -70,8 +70,9 @@ module Bullet
       !!@enable
     end
 
+    # Rails.root might be nil if `railties` is a dependency on a project that does not use Rails
     def app_root
-      @app_root ||= (defined?(::Rails.root) ? Rails.root.to_s : Dir.pwd).to_s
+      @app_root ||= (defined?(::Rails.root) && !::Rails.root.nil? ? Rails.root.to_s : Dir.pwd).to_s
     end
 
     def n_plus_one_query_enable?


### PR DESCRIPTION
Fixes #568 by checking if Rails.root is both _defined and different than nil_ before using it.