### PR TITLE
Fix typo in tests

### DIFF
--- a/spec/bullet/ext/object_spec.rb
+++ b/spec/bullet/ext/object_spec.rb
@@ -10,7 +10,7 @@ describe Object do
     end
 
     if mongoid?
-      it 'should return class with namesapce and id composition' do
+      it 'should return class with namespace and id composition' do
         post = Mongoid::Post.first
         expect(post.bullet_key).to eq("Mongoid::Post:#{post.id}")
       end

--- a/spec/integration/active_record/association_spec.rb
+++ b/spec/integration/active_record/association_spec.rb
@@ -129,7 +129,7 @@ if active_record?
         expect(Bullet::Detector::Association).to be_completely_preloading_associations
       end
 
-      it 'should detect unused preload with post => commnets, no category => posts' do
+      it 'should detect unused preload with post => comments, no category => posts' do
         Category.includes(posts: :comments).each { |category| category.posts.map(&:name) }
         Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
         expect(Bullet::Detector::Association).to be_unused_preload_associations_for(Post, :comments)
@@ -202,7 +202,7 @@ if active_record?
         expect(Bullet::Detector::Association).to be_completely_preloading_associations
       end
 
-      it 'should detect preload with post => commnets' do
+      it 'should detect preload with post => comments' do
         Post.first.comments.map(&:name)
         Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
         expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations

--- a/spec/integration/mongoid/association_spec.rb
+++ b/spec/integration/mongoid/association_spec.rb
@@ -118,7 +118,7 @@ if mongoid?
           expect(Bullet::Detector::Association).to be_completely_preloading_associations
         end
 
-        it 'should detect preload with post => commnets' do
+        it 'should detect preload with post => comments' do
           Mongoid::Post.first.comments.map(&:name)
           Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
           expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations


### PR DESCRIPTION
Fix typo in following files
- spec/integration/mongoid/association_spec.rb
- spec/integration/active_record/association_spec.rb
- spec/bullet/ext/object_spec.rb