### PR TITLE
Fix onload called twice

### DIFF
--- a/lib/bullet/bullet_xhr.js
+++ b/lib/bullet/bullet_xhr.js
@@ -20,6 +20,7 @@
     if (this.onload) {
       this._storedOnload = this.onload;
     }
+    this.onload = null
     this.addEventListener("load", bulletXHROnload);
     return Reflect.apply(oldSend, this, arguments);
   }


### PR DESCRIPTION
XMLHttpRequest overrided by bullet_xhr.js is call twice `onload` callback.

1. `this.onload`
2. `_storedOnload` copied from `this.onload`

So I fixed it to disable case 1.