### PR TITLE
Add Bullet.stacktrace_filter= for custom stacktrace filtering

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -36,7 +36,7 @@ module Bullet
                 :stacktrace_excludes,
                 :skip_html_injection
     attr_reader :whitelist
-    attr_accessor :add_footer, :orm_patches_applied, :skip_http_headers
+    attr_accessor :add_footer, :orm_patches_applied, :skip_http_headers, :stacktrace_filter
 
     available_notifiers =
       UniformNotifier::AVAILABLE_NOTIFIERS.select { |notifier| notifier != :raise }.map { |notifier| "#{notifier}=" }

--- a/spec/bullet_spec.rb
+++ b/spec/bullet_spec.rb
@@ -133,4 +133,25 @@ describe Bullet, focused: true do
       end
     end
   end
+
+  describe "#stacktrace_filter=" do
+    context "when set" do
+      it "can filter the stack trace according to custom logic" do
+        Bullet.stacktrace_filter = ->(location) { location.match? /spec/ }
+        Post.all.each { |post| post.comments.map &:name }
+        first_notification = Bullet.collected_n_plus_one_query_notifications.first
+        expect(first_notification.instance_variable_get(:@callers).map(&:to_s)).to all match /spec/
+      end
+    end
+
+    context "when not set" do
+      before { Bullet.stacktrace_filter = nil }
+
+      it "only shows items from within the app" do
+        Post.all.each { |post| post.comments.map &:name }
+        first_notification = Bullet.collected_n_plus_one_query_notifications.first
+        expect(first_notification.instance_variable_get(:@callers).map(&:to_s)).to all match /bullet/
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds functionality for specifying a custom filter for the stacktrace, based on my comments in #342, #426, #491. It can be used like this:

```ruby
Bullet.stacktrace_filter = -> (location) { location.match? /(foo)?bar/ }
```
or even just
```ruby
Bullet.stacktrace_filter = -> { true }
```
if you wanted a full stacktrace each time.

But if you don't specify it, or it is set to nil, it maintains the existing behaviour, for backwards compatibility
```ruby
Bullet.stacktrace_filter = nil # replicate existing behaviour
```