### PR TITLE
Support Rack::Files::Iterator responses

### DIFF
--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -84,7 +84,7 @@ module Bullet
     def response_body(response)
       if response.respond_to?(:body)
         Array === response.body ? response.body.first : response.body
-      else
+      elsif response.respond_to?(:first)
         response.first
       end
     end

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+require 'rack/files'
+
 module Bullet
   describe Rack do
     let(:middleware) { Bullet::Rack.new app }
@@ -259,6 +261,15 @@ module Bullet
 
         it 'should return the plain body string' do
           expect(middleware.response_body(response)).to eq body_string
+        end
+      end
+
+      context 'when `response` is a Rack::Files::Iterator' do
+        let(:response) { instance_double(::Rack::Files::Iterator) }
+        before { allow(response).to receive(:is_a?).with(::Rack::Files::Iterator) { true } }
+
+        it 'should return nil' do
+          expect(middleware.response_body(response)).to be_nil
         end
       end
     end


### PR DESCRIPTION
When using the `Rack::Static` middleware, the response will be a `Rack::Files::Iterator`. Such a response will break
`Bullet::Rack#response_body`, with the result that non-HTML files will not be served correctly.

Seen when trying to use the Sidekiq admin engine in a Rails application that also uses Bullet.