### PR TITLE
Change URL of the bullet-test project to use an updated version

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Bullet outputs some details info, to enable debug mode, set
 ## Demo
 
 Bullet is designed to function as you browse through your application in development. To see it in action,
-you can visit [https://github.com/flyerhzm/bullet_test](https://github.com/flyerhzm/bullet_test) or
+you can visit [https://github.com/fabioperrella/bullet-test](https://github.com/fabioperrella/bullet-test) or
 follow these steps to create, detect, and fix example query problems.
 
 1\. Create an example application


### PR DESCRIPTION
Hi!

I noticed that the project that it is referenced in the README is outdated, using Rails 4.2

So, I created a fresh one using the latest Rails version