### PR TITLE
Fix Mongoid 7 view iteration

### DIFF
--- a/lib/bullet/mongoid7x.rb
+++ b/lib/bullet/mongoid7x.rb
@@ -23,16 +23,31 @@ module Bullet
         end
 
         def each(&block)
-          return to_enum unless block
+          return to_enum unless block_given?
 
-          records = []
-          origin_each { |record| records << record }
-          if records.length > 1
-            Bullet::Detector::NPlusOneQuery.add_possible_objects(records)
-          elsif records.size == 1
-            Bullet::Detector::NPlusOneQuery.add_impossible_object(records.first)
+          first_document = nil
+          document_count = 0
+
+          origin_each do |document|
+            document_count += 1
+
+            if document_count == 1
+              first_document = document
+            elsif document_count == 2
+              Bullet::Detector::NPlusOneQuery.add_possible_objects([first_document, document])
+              yield(first_document)
+              first_document = nil
+              yield(document)
+            else
+              Bullet::Detector::NPlusOneQuery.add_possible_objects(document)
+              yield(document)
+            end
           end
-          records.each(&block)
+
+          if document_count == 1
+            Bullet::Detector::NPlusOneQuery.add_impossible_object(first_document)
+            yield(first_document)
+          end
         end
 
         def eager_load(docs)

--- a/lib/bullet/mongoid7x.rb
+++ b/lib/bullet/mongoid7x.rb
@@ -48,6 +48,8 @@ module Bullet
             Bullet::Detector::NPlusOneQuery.add_impossible_object(first_document)
             yield(first_document)
           end
+
+          self
         end
 
         def eager_load(docs)


### PR DESCRIPTION
MongoDB/Mongoid uses cursors for queries by default, unlike SQL
dbs/ActiveRecord. Users of MongoDB expect that find operations by
default will behave like ActiveRecord's find_in_batches. It should be
possible to iterate over the results of a query and only the single
batch of results from the db should be in memory at one time, which
allows code to iterate over very large collections or collections with
large documents safely.

Bullet's Mongoid integration breaks this by consuming the entire
enumerable into memory before yielding. The code is now changed to
iteratively yield results.

I've only fixed the Mongoid 7 version because I've been able to validate its behavior against my app using Mongoid 7 whereas I cannot get any of the current Mongoid test suites in Bullet to function correctly.