### PR TITLE
Auto corrected by following Lint Ruby Lint/UnusedMethodArgument

### DIFF
--- a/lib/bullet/mongoid7x.rb
+++ b/lib/bullet/mongoid7x.rb
@@ -22,7 +22,7 @@ module Bullet
           result
         end
 
-        def each(&block)
+        def each()
           return to_enum unless block_given?
 
           first_document = nil


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/UnusedMethodArgument

Click [here](https://awesomecode.io/repos/flyerhzm/bullet/lint_configs/ruby/10901) to configure it on awesomecode.io