### PR TITLE
Auto corrected by following Lint Ruby Style/ExplicitBlockArgument

### DIFF
--- a/lib/bullet/active_record41.rb
+++ b/lib/bullet/active_record41.rb
@@ -75,8 +75,8 @@ module Bullet
       ::ActiveRecord::FinderMethods.class_eval do
         # add includes in scope
         alias_method :origin_find_with_associations, :find_with_associations
-        def find_with_associations
-          return origin_find_with_associations { |r| yield r } if block_given?
+        def find_with_associations(&block)
+          return origin_find_with_associations(&block) if block_given?
 
           records = origin_find_with_associations
           if Bullet.start?

--- a/lib/bullet/active_record42.rb
+++ b/lib/bullet/active_record42.rb
@@ -90,8 +90,8 @@ module Bullet
       ::ActiveRecord::FinderMethods.class_eval do
         # add includes in scope
         alias_method :origin_find_with_associations, :find_with_associations
-        def find_with_associations
-          return origin_find_with_associations { |r| yield r } if block_given?
+        def find_with_associations(&block)
+          return origin_find_with_associations(&block) if block_given?
 
           records = origin_find_with_associations
           if Bullet.start?

--- a/lib/bullet/active_record5.rb
+++ b/lib/bullet/active_record5.rb
@@ -78,8 +78,8 @@ module Bullet
       ::ActiveRecord::FinderMethods.prepend(
         Module.new do
           # add includes in scope
-          def find_with_associations
-            return super { |r| yield r } if block_given?
+          def find_with_associations(&block)
+            return super(&block) if block_given?
 
             records = super
             if Bullet.start?

--- a/lib/bullet/stack_trace_filter.rb
+++ b/lib/bullet/stack_trace_filter.rb
@@ -53,11 +53,11 @@ module Bullet
       IS_RUBY_19 ? location : location.absolute_path.to_s
     end
 
-    def select_caller_locations
+    def select_caller_locations(&block)
       if IS_RUBY_19
-        caller.select { |caller_path| yield caller_path }
+        caller.select(&block)
       else
-        caller_locations.select { |location| yield location }
+        caller_locations.select(&block)
       end
     end
   end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/ExplicitBlockArgument

Click [here](https://awesomecode.io/repos/flyerhzm/bullet/lint_configs/ruby/109029) to configure it on awesomecode.io