### PR TITLE
Run ruby 3.1 on github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0.3
+        ruby-version: 3.1
         bundler-cache: true
     - name: Run tests
       run: bundle exec rake


### PR DESCRIPTION
[Rails 7.0.1 was released which supports Ruby 3.1](https://rubyonrails.org/2022/1/6/Rails-7-0-1-has-been-released)