### PR TITLE
Replace Array() with Array.wrap()

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -109,7 +109,7 @@ module Bullet
     end
 
     def get_safelist_associations(type, class_name)
-      Array(@safelist[type][class_name])
+      Array.wrap(@safelist[type][class_name])
     end
 
     def reset_safelist

--- a/lib/bullet/active_record5.rb
+++ b/lib/bullet/active_record5.rb
@@ -179,7 +179,7 @@ module Bullet
                 refl = reflection.through_reflection
                 Bullet::Detector::NPlusOneQuery.call_association(owner, refl.name)
                 association = owner.association refl.name
-                Array(association.target).each do |through_record|
+                Array.wrap(association.target).each do |through_record|
                   Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
                 end
 

--- a/lib/bullet/active_record52.rb
+++ b/lib/bullet/active_record52.rb
@@ -152,7 +152,7 @@ module Bullet
               if is_a? ::ActiveRecord::Associations::ThroughAssociation
                 Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
                 association = owner.association reflection.through_reflection.name
-                Array(association.target).each do |through_record|
+                Array.wrap(association.target).each do |through_record|
                   Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
                 end
 
@@ -199,7 +199,7 @@ module Bullet
                 if is_a? ::ActiveRecord::Associations::ThroughAssociation
                   Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
                   association = owner.association reflection.through_reflection.name
-                  Array(association.target).each do |through_record|
+                  Array.wrap(association.target).each do |through_record|
                     Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
                   end
 

--- a/lib/bullet/active_record60.rb
+++ b/lib/bullet/active_record60.rb
@@ -179,7 +179,7 @@ module Bullet
               if is_a? ::ActiveRecord::Associations::ThroughAssociation
                 Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
                 association = owner.association(reflection.through_reflection.name)
-                Array(association.target).each do |through_record|
+                Array.wrap(association.target).each do |through_record|
                   Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
                 end
 
@@ -226,7 +226,7 @@ module Bullet
                 if is_a? ::ActiveRecord::Associations::ThroughAssociation
                   Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
                   association = owner.association(reflection.through_reflection.name)
-                  Array(association.target).each do |through_record|
+                  Array.wrap(association.target).each do |through_record|
                     Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
                   end
 

--- a/lib/bullet/active_record61.rb
+++ b/lib/bullet/active_record61.rb
@@ -179,7 +179,7 @@ module Bullet
               if is_a? ::ActiveRecord::Associations::ThroughAssociation
                 Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
                 association = owner.association(reflection.through_reflection.name)
-                Array(association.target).each do |through_record|
+                Array.wrap(association.target).each do |through_record|
                   Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
                 end
 
@@ -226,7 +226,7 @@ module Bullet
                 if is_a? ::ActiveRecord::Associations::ThroughAssociation
                   Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
                   association = owner.association(reflection.through_reflection.name)
-                  Array(association.target).each do |through_record|
+                  Array.wrap(association.target).each do |through_record|
                     Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
                   end
 

--- a/lib/bullet/active_record70.rb
+++ b/lib/bullet/active_record70.rb
@@ -182,7 +182,7 @@ module Bullet
               if is_a? ::ActiveRecord::Associations::ThroughAssociation
                 Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
                 association = owner.association(reflection.through_reflection.name)
-                Array(association.target).each do |through_record|
+                Array.wrap(association.target).each do |through_record|
                   Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
                 end
 
@@ -229,7 +229,7 @@ module Bullet
                 if is_a? ::ActiveRecord::Associations::ThroughAssociation
                   Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
                   association = owner.association(reflection.through_reflection.name)
-                  Array(association.target).each do |through_record|
+                  Array.wrap(association.target).each do |through_record|
                     Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
                   end
 

--- a/lib/bullet/detector/counter_cache.rb
+++ b/lib/bullet/detector/counter_cache.rb
@@ -20,7 +20,7 @@ module Bullet
           return unless Bullet.start?
           return unless Bullet.counter_cache_enable?
 
-          objects = Array(object_or_objects)
+          objects = Array.wrap(object_or_objects)
           return if objects.map(&:bullet_primary_key_value).compact.empty?
 
           Bullet.debug(
@@ -54,7 +54,7 @@ module Bullet
         private
 
         def create_notification(klazz, associations)
-          notify_associations = Array(associations) - Bullet.get_safelist_associations(:counter_cache, klazz)
+          notify_associations = Array.wrap(associations) - Bullet.get_safelist_associations(:counter_cache, klazz)
 
           if notify_associations.present?
             notice = Bullet::Notification::CounterCache.new klazz, notify_associations

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -33,7 +33,7 @@ module Bullet
           return unless Bullet.start?
           return unless Bullet.n_plus_one_query_enable?
 
-          objects = Array(object_or_objects)
+          objects = Array.wrap(object_or_objects)
           return if objects.map(&:bullet_primary_key_value).compact.empty?
           return if objects.all? { |obj| obj.class.name =~ /^HABTM_/ }
 
@@ -95,7 +95,7 @@ module Bullet
         private
 
         def create_notification(callers, klazz, associations)
-          notify_associations = Array(associations) - Bullet.get_safelist_associations(:n_plus_one_query, klazz)
+          notify_associations = Array.wrap(associations) - Bullet.get_safelist_associations(:n_plus_one_query, klazz)
 
           if notify_associations.present?
             notice = Bullet::Notification::NPlusOneQuery.new(callers, klazz, notify_associations)

--- a/lib/bullet/detector/unused_eager_loading.rb
+++ b/lib/bullet/detector/unused_eager_loading.rb
@@ -65,7 +65,7 @@ module Bullet
         private
 
         def create_notification(callers, klazz, associations)
-          notify_associations = Array(associations) - Bullet.get_safelist_associations(:unused_eager_loading, klazz)
+          notify_associations = Array.wrap(associations) - Bullet.get_safelist_associations(:unused_eager_loading, klazz)
 
           if notify_associations.present?
             notice = Bullet::Notification::UnusedEagerLoading.new(callers, klazz, notify_associations)


### PR DESCRIPTION
We had an issue https://github.com/rubyforgood/human-essentials/issues/3024 where we defined a `to_a` method on an ActiveRecord class. This method is a conversion method, meant to convert something (which may not be an array) into an array (which may not directly correspond with the original object).

For example, calling `to_a` on a hash will get you an array of key/value pairs of the hash.

This caused crashes on our local with bullet running, since the `Array()` method falls back to calling `to_a` on the object. In our case the result of this was not a list of ActiveRecord objects as expected.

ActiveSupport's `Array.wrap()` method, on the other hand, only uses `to_ary` (which is only implemented in array-like objects) and correctly wraps any single objects in an array without calling `to_a` on it.

This PR replaces all `Array()` calls with `Array.wrap()` calls which should fix this issue.