### PR TITLE
Fix Rails example path in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ $ rails g scaffold comment name:string post_id:integer
 $ bundle exec rake db:migrate
 ```
 
-2\. Change `app/model/post.rb` and `app/model/comment.rb`
+2\. Change `app/models/post.rb` and `app/models/comment.rb`
 
 ```ruby
 class Post < ActiveRecord::Base


### PR DESCRIPTION
The Rails example in the `README.md` contains a few incorrect paths: "app/model" should be "app/models" in two locations.

This PR fixes that.

I was able to completely follow the instruction after this change. Thank you for the step-by-step instructions, by the way!