### PR TITLE
Fix n+1 false positives in AR7.0

### DIFF
--- a/lib/bullet/active_record70.rb
+++ b/lib/bullet/active_record70.rb
@@ -170,6 +170,13 @@ module Bullet
             end
             super
           end
+
+          def inversed_from_queries(record)
+            if Bullet.start? && inversable?(record)
+              Bullet::Detector::NPlusOneQuery.add_inversed_object(owner, reflection.name)
+            end
+            super
+          end
         end
       )
 

--- a/spec/integration/active_record/association_spec.rb
+++ b/spec/integration/active_record/association_spec.rb
@@ -58,6 +58,19 @@ if active_record?
         expect(Bullet::Detector::Association).to be_completely_preloading_associations
       end
 
+      it 'should detect non preload comment => post with inverse_of from a query' do
+        Post.first.comments.find_each do |comment|
+          comment.name
+          comment.post.name
+        end
+
+        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
+        expect(Post.first.comments.count).not_to eq(0)
+        expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
+
+        expect(Bullet::Detector::Association).to be_completely_preloading_associations
+      end
+
       it 'should detect non preload post => comments with empty?' do
         Post.all.each { |post| post.comments.empty? }
         Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations


### PR DESCRIPTION
I don't know enough about this gem and AR to explain in detail what's wrong. But let me try:

What I've been able to assess is in AR 7.0, inversed objects don't get added when a children records get loaded via a query (?) instead of an association call 🤔 

Don't know if it explains well enough but right now, this doesn't raise an n+1 error
```ruby
Post.first.comments.each { _1.post.name }
```

but this does:
```ruby
Post.first.comments.all.each { _1.post.name }
# `all` can be replaced by some other querying methods like where/find_each/order and so on?
```