### PR TITLE
adds check for rails 7.1 support to allow rails 7.1.0.alpha

### DIFF
--- a/lib/bullet/dependency.rb
+++ b/lib/bullet/dependency.rb
@@ -31,6 +31,8 @@ module Bullet
             'active_record61'
           elsif active_record70?
             'active_record70'
+          elsif active_record71?
+            'active_record71'
           else
             raise "Bullet does not support active_record #{::ActiveRecord::VERSION::STRING} yet"
           end
@@ -104,6 +106,10 @@ module Bullet
 
     def active_record70?
       active_record7? && ::ActiveRecord::VERSION::MINOR == 0
+    end
+
+    def active_record71?
+      active_record7? && ::ActiveRecord::VERSION::MINOR == 1
     end
 
     def mongoid4x?


### PR DESCRIPTION
@flyerhzm -- I didn't actually test bullet to see if it works against Rails 7.1, I just added a check to allow it to load, so using bullet under Rails 7.1 can be considered experimental.

However, why do you have this special checking code at all, when Gemspec provides this functionality for you through version management:
```
  s.add_runtime_dependency 'activesupport', '>= 3.0.0'
```

I think the common pattern is 
```
  s.add_runtime_dependency 'activesupport', '>= 3.0.0', , '<= 7.0.4'
```

either way, this fixes bullet to allow it to work with Rails 7.1.0

