### PR TITLE
experimental switch to allow untested rails

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -9,6 +9,15 @@ require 'bullet/dependency'
 require 'bullet/stack_trace_filter'
 
 module Bullet
+
+  def self.allow_untested_rails=(setting)
+    @allow_untested_rails = setting
+  end
+
+  def self.allow_untested_rails?
+    !!@allow_untested_rails
+  end
+
   extend Dependency
 
   autoload :ActiveRecord, "bullet/#{active_record_version}" if active_record?

--- a/lib/bullet/dependency.rb
+++ b/lib/bullet/dependency.rb
@@ -32,7 +32,12 @@ module Bullet
           elsif active_record70?
             'active_record70'
           else
-            raise "Bullet does not support active_record #{::ActiveRecord::VERSION::STRING} yet"
+            logger = Logger.new(STDOUT)
+            if Bullet.allow_untested_rails?
+              UniformNotifier.warn("Bullet does not yet confirmed to support your version of Rails (active_record #{::ActiveRecord::VERSION::STRING}). Using Bullet with the unsupported version Rails is EXPERIMENTAL and may not work correctly. Please report bugs to https://github.com/flyerhzm/bullet")
+            else
+              raise "Bullet does not yet confirmed to support your version of Rails (active_record #{::ActiveRecord::VERSION::STRING}). To use anyway, set allow_untested_rails = true"
+            end
           end
         end
     end


### PR DESCRIPTION
**this does not actually work**
 
it won't work this way because the rails dependency check is in the loader, creating a catch-22 problem: In order to set `Bullet.allow_untested_rails = true` you would need Bullet loaded first. But because the check happens during Bullet's load, there's no opportunity to set this before Bullet loads. 

the way the code is currently written, this won't work. (but I think is an ideal solution, because it warns people but gives them the option of allowing the untested Rails).

I would recommend switching to the standard Gem configuration syntax, so the Bullet config would be rewritten like this:

```
Bullet.setup do |config|
  config.enable = true
  config.bullet_logger = true
end
```

in the Bullet class itself, you would then put:

```
  def self.setup
    yield self
  end
```

this was too much beyond the scope of what I could refactor but wanted to propose it as a change. 

benefits:
1) standardized way to configure gems (nearly all Gems I see use this style)
2) You eliminate the catch-22 problem described above


what do you think?

Like I said, this PR is a proof-of-concept only and does not function, do not merge. 

Switching to this config syntax style would involve a breaking change