### PR TITLE
Fix false positive n+1 for has many through associations

### DIFF
--- a/lib/bullet/active_record5.rb
+++ b/lib/bullet/active_record5.rb
@@ -177,10 +177,12 @@ module Bullet
             if Bullet.start?
               if is_a? ::ActiveRecord::Associations::ThroughAssociation
                 refl = reflection.through_reflection
-                Bullet::Detector::NPlusOneQuery.call_association(owner, refl.name)
-                association = owner.association refl.name
-                Array.wrap(association.target).each do |through_record|
-                  Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+                association = owner.association(refl.name)
+                if association.loaded?
+                  Bullet::Detector::NPlusOneQuery.call_association(owner, refl.name)
+                  Array.wrap(association.target).each do |through_record|
+                    Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+                  end
                 end
 
                 if refl.through_reflection?

--- a/lib/bullet/active_record52.rb
+++ b/lib/bullet/active_record52.rb
@@ -150,10 +150,12 @@ module Bullet
 
             if Bullet.start?
               if is_a? ::ActiveRecord::Associations::ThroughAssociation
-                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
-                association = owner.association reflection.through_reflection.name
-                Array.wrap(association.target).each do |through_record|
-                  Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+                association = owner.association(reflection.through_reflection.name)
+                if association.loaded?
+                  Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
+                  Array.wrap(association.target).each do |through_record|
+                    Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+                  end
                 end
 
                 if reflection.through_reflection != through_reflection

--- a/lib/bullet/active_record60.rb
+++ b/lib/bullet/active_record60.rb
@@ -177,10 +177,12 @@ module Bullet
 
             if Bullet.start?
               if is_a? ::ActiveRecord::Associations::ThroughAssociation
-                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
                 association = owner.association(reflection.through_reflection.name)
-                Array.wrap(association.target).each do |through_record|
-                  Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+                if association.loaded?
+                  Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
+                  Array.wrap(association.target).each do |through_record|
+                    Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+                  end
                 end
 
                 if reflection.through_reflection != through_reflection

--- a/lib/bullet/active_record61.rb
+++ b/lib/bullet/active_record61.rb
@@ -177,10 +177,12 @@ module Bullet
 
             if Bullet.start?
               if is_a? ::ActiveRecord::Associations::ThroughAssociation
-                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
                 association = owner.association(reflection.through_reflection.name)
-                Array.wrap(association.target).each do |through_record|
-                  Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+                if association.loaded?
+                  Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
+                  Array.wrap(association.target).each do |through_record|
+                    Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+                  end
                 end
 
                 if reflection.through_reflection != through_reflection

--- a/lib/bullet/active_record70.rb
+++ b/lib/bullet/active_record70.rb
@@ -180,10 +180,12 @@ module Bullet
 
             if Bullet.start?
               if is_a? ::ActiveRecord::Associations::ThroughAssociation
-                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
                 association = owner.association(reflection.through_reflection.name)
-                Array.wrap(association.target).each do |through_record|
-                  Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+                if association.loaded?
+                  Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
+                  Array.wrap(association.target).each do |through_record|
+                    Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+                  end
                 end
 
                 if reflection.through_reflection != through_reflection

--- a/spec/integration/active_record/association_spec.rb
+++ b/spec/integration/active_record/association_spec.rb
@@ -474,7 +474,15 @@ if active_record?
       end
 
       it 'should detect preload associations' do
-        Firm.includes(:clients).each { |firm| firm.clients.map(&:name) }
+        Firm.preload(:clients).each { |firm| firm.clients.map(&:name) }
+        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
+        expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
+
+        expect(Bullet::Detector::Association).to be_completely_preloading_associations
+      end
+
+      it 'should detect eager load association' do
+        Firm.eager_load(:clients).each { |firm| firm.clients.map(&:name) }
         Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
         expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
 


### PR DESCRIPTION
Happens when  `eager_load` is used. Eager load uses a single query (with a left join) to pull the records and it doesn't build/load any records for the join table. Seems that using `if association.loaded?` solves the problem.