### PR TITLE
Added CallStacks support for avoid eager loading

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -144,6 +144,7 @@ module Bullet
       Thread.current[:bullet_impossible_objects] = Bullet::Registry::Object.new
       Thread.current[:bullet_inversed_objects] = Bullet::Registry::Base.new
       Thread.current[:bullet_eager_loadings] = Bullet::Registry::Association.new
+      Thread.current[:bullet_call_stacks] = Bullet::Registry::CallStack.new
 
       Thread.current[:bullet_counter_possible_objects] ||= Bullet::Registry::Object.new
       Thread.current[:bullet_counter_impossible_objects] ||= Bullet::Registry::Object.new

--- a/lib/bullet/detector/association.rb
+++ b/lib/bullet/detector/association.rb
@@ -13,6 +13,7 @@ module Bullet
             'Detector::Association#add_object_associations',
             "object: #{object.bullet_key}, associations: #{associations}"
           )
+          call_stacks.add(object.bullet_key)
           object_associations.add(object.bullet_key, associations)
         end
 
@@ -25,6 +26,7 @@ module Bullet
             'Detector::Association#add_call_object_associations',
             "object: #{object.bullet_key}, associations: #{associations}"
           )
+          call_stacks.add(object.bullet_key)
           call_object_associations.add(object.bullet_key, associations)
         end
 
@@ -75,6 +77,12 @@ module Bullet
         # e.g. { ["Post:1", "Post:2"] => [:comments, :user] }
         def eager_loadings
           Thread.current[:bullet_eager_loadings]
+        end
+
+        # cal_stacks keeps stacktraces where querie-objects were called from.
+        # e.g. { 'Object:111' => [SomeProject/app/controllers/...] }
+        def call_stacks
+          Thread.current[:bullet_call_stacks]
         end
       end
     end

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -25,7 +25,7 @@ module Bullet
           )
           if !excluded_stacktrace_path? && conditions_met?(object, associations)
             Bullet.debug('detect n + 1 query', "object: #{object.bullet_key}, associations: #{associations}")
-            create_notification caller_in_project, object.class.to_s, associations
+            create_notification caller_in_project(object.bullet_key), object.class.to_s, associations
           end
         end
 

--- a/lib/bullet/detector/unused_eager_loading.rb
+++ b/lib/bullet/detector/unused_eager_loading.rb
@@ -20,7 +20,7 @@ module Bullet
             next if object_association_diff.empty?
 
             Bullet.debug('detect unused preload', "object: #{bullet_key}, associations: #{object_association_diff}")
-            create_notification(caller_in_project, bullet_key.bullet_class_name, object_association_diff)
+            create_notification(caller_in_project(bullet_key), bullet_key.bullet_class_name, object_association_diff)
           end
         end
 

--- a/lib/bullet/registry.rb
+++ b/lib/bullet/registry.rb
@@ -5,5 +5,6 @@ module Bullet
     autoload :Base, 'bullet/registry/base'
     autoload :Object, 'bullet/registry/object'
     autoload :Association, 'bullet/registry/association'
+    autoload :CallStack, 'bullet/registry/call_stack'
   end
 end

--- a/lib/bullet/registry/call_stack.rb
+++ b/lib/bullet/registry/call_stack.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Bullet
+  module Registry
+    class CallStack < Base
+      # remembers found association backtrace
+      def add(key)
+        @registry[key] = Thread.current.backtrace
+      end
+    end
+  end
+end

--- a/spec/bullet/detector/unused_eager_loading_spec.rb
+++ b/spec/bullet/detector/unused_eager_loading_spec.rb
@@ -65,6 +65,11 @@ module Bullet
           expect(UnusedEagerLoading).not_to receive(:create_notification).with('Post', [:association])
           UnusedEagerLoading.check_unused_preload_associations
         end
+
+        it 'should create call stack for notification' do
+          UnusedEagerLoading.add_object_associations(@post, :association)
+          expect(UnusedEagerLoading.send(:call_stacks).registry).not_to be_empty
+        end
       end
 
       context '.add_eager_loadings' do


### PR DESCRIPTION
Hello! I think this is working solution for problem:
https://github.com/flyerhzm/bullet/issues/384

Btw, this problem can occurs on Puma servers or RSpec testing (my current build Rails 5.2.X + Ruby 2.7.5) in case originally "broken" query backtrace always behind borders of :caller_locations method called in StackTraceFilter. So I thought memorizing original backtrace could be a good decision. 