### PR TITLE
fix: don't insert bullet middleware before csp middleware in API only applications

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -23,7 +23,7 @@ module Bullet
   if defined?(Rails::Railtie)
     class BulletRailtie < Rails::Railtie
       initializer 'bullet.configure_rails_initialization' do |app|
-        if defined?(ActionDispatch::ContentSecurityPolicy::Middleware)
+        if defined?(ActionDispatch::ContentSecurityPolicy::Middleware) && !app.config.api_only
           app.middleware.insert_before ActionDispatch::ContentSecurityPolicy::Middleware, Bullet::Rack
         else
           app.middleware.use Bullet::Rack

--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -23,7 +23,7 @@ module Bullet
   if defined?(Rails::Railtie)
     class BulletRailtie < Rails::Railtie
       initializer 'bullet.configure_rails_initialization' do |app|
-        if defined?(ActionDispatch::ContentSecurityPolicy::Middleware) && !app.config.api_only
+        if defined?(ActionDispatch::ContentSecurityPolicy::Middleware) && app.middleware.include?(ActionDispatch::ContentSecurityPolicy::Middleware)
           app.middleware.insert_before ActionDispatch::ContentSecurityPolicy::Middleware, Bullet::Rack
         else
           app.middleware.use Bullet::Rack


### PR DESCRIPTION
Per https://github.com/flyerhzm/bullet/issues/637, API-only rails applications will fail to start when using bullet `7.0.5`.

https://github.com/flyerhzm/bullet/pull/634 made a change to insert the `Bullet::Rack` middleware before `ActionDispatch::ContentSecurityPolicy::Middleware`. This will only conditionally `insert_before` if `ActionDispatch::ContentSecurityPolicy::Middleware` is defined. It seems this is defined regardless of it being in the middleware stack or not.

This PR updates the logic to check if the `ActionDispatch::ContentSecurityPolicy::Middleware` middleware is in the stack, and if so, only then add `Bullet::Rack` before it.

### Validation

You can validate this change using a API-only rails application. You can change an existing application to API only by adding `config.api_only = true` to `application.rb`, or create a new one:

Create a new API only application:
```
rails new example_app --api
```

Install bullet `7.0.5`: `bundle add bullet --version 7.0.5`

Doing `rails c` or `rails s` will fail, citing the missing middleware.

Update your `Gemfile` to use this branch instead:
```
gem 'bullet', git: 'https://github.com/MichaelLah/bullet.git', branch: 'fix-csp-middleware-api-only'
```
`bundle i`, and confirm you can start your API-only application with `rails c` or `rails s`
