### PR TITLE
Add always_append_html_body option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* Added `always_append_html_body` option, so the html snippet is always included even if there are no notifications
+
 ## 7.0.7 (03/01/2023)
 
 * Check `Rails.application.config.content_security_policy` before insert `Bullet::Rack`

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The code above will enable all of the Bullet notification systems:
    item is a line number, a Range of line numbers, or a (bare) method name, to exclude only particular lines in a file.
 * `Bullet.slack`: add notifications to slack
 * `Bullet.raise`: raise errors, useful for making your specs fail unless they have optimized queries
+* `Bullet.always_append_html_body`: always append the html body even if no notifications are present. Note: `console` or `add_footer` must also be true. Useful for Single Page Applications where the initial page load might not have any notifications present.
 
 
 Bullet also allows you to disable any of its detectors.

--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -40,7 +40,7 @@ module Bullet
                 :stacktrace_excludes,
                 :skip_html_injection
     attr_reader :safelist
-    attr_accessor :add_footer, :orm_patches_applied, :skip_http_headers
+    attr_accessor :add_footer, :orm_patches_applied, :skip_http_headers, :always_append_html_body
 
     available_notifiers =
       UniformNotifier::AVAILABLE_NOTIFIERS.select { |notifier| notifier != :raise }.map { |notifier| "#{notifier}=" }

--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -18,7 +18,7 @@ module Bullet
 
       response_body = nil
 
-      if Bullet.notification?
+      if Bullet.notification? || Bullet.always_append_html_body
         if Bullet.inject_into_page? && !file?(headers) && !sse?(headers) && !empty?(response) && status == 200
           if html_request?(headers, response)
             response_body = response_body(response)


### PR DESCRIPTION
Please let me know if there are any contributor guidelines that I need to follow!

## Change
Adds a new option: `always_append_html_body`. When true, attempt to append the relevant html (this is dependent on `add_footer` or `console` also being true) even if no notifications are present

## Why
I have a single page application and noticed that the relevant html snippets were not included on the initial page load because there were no notifications. This meant that for all subsequent xhr requests I was not being notified in the footer/console.