### PR TITLE
Detect n+1 count queries from ActiveRecord::Associations::CollectionProxy#count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Added `always_append_html_body` option, so the html snippet is always included even if there are no notifications
 * Added detection of n+1 count queries from `count` method
+* Changed the counter cache notification title to recommend using `size`
 
 ## 7.0.7 (03/01/2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next Release
 
 * Added `always_append_html_body` option, so the html snippet is always included even if there are no notifications
+* Added detection of n+1 count queries from `count` method
 
 ## 7.0.7 (03/01/2023)
 

--- a/lib/bullet/active_record4.rb
+++ b/lib/bullet/active_record4.rb
@@ -176,6 +176,15 @@ module Bullet
           result
         end
       end
+
+      ::ActiveRecord::Associations::CollectionProxy.class_eval do
+        def count
+          if Bullet.start?
+            Bullet::Detector::CounterCache.add_counter_cache(proxy_association.owner, proxy_association.reflection.name)
+          end
+          super
+        end
+      end
     end
   end
 end

--- a/lib/bullet/active_record41.rb
+++ b/lib/bullet/active_record41.rb
@@ -168,6 +168,15 @@ module Bullet
           origin_count_records
         end
       end
+
+      ::ActiveRecord::Associations::CollectionProxy.class_eval do
+        def count
+          if Bullet.start?
+            Bullet::Detector::CounterCache.add_counter_cache(proxy_association.owner, proxy_association.reflection.name)
+          end
+          super
+        end
+      end
     end
   end
 end

--- a/lib/bullet/active_record42.rb
+++ b/lib/bullet/active_record42.rb
@@ -233,6 +233,15 @@ module Bullet
           origin_count_records
         end
       end
+
+      ::ActiveRecord::Associations::CollectionProxy.class_eval do
+        def count
+          if Bullet.start?
+            Bullet::Detector::CounterCache.add_counter_cache(proxy_association.owner, proxy_association.reflection.name)
+          end
+          super
+        end
+      end
     end
   end
 end

--- a/lib/bullet/active_record5.rb
+++ b/lib/bullet/active_record5.rb
@@ -260,6 +260,17 @@ module Bullet
           end
         end
       )
+
+      ::ActiveRecord::Associations::CollectionProxy.prepend(
+        Module.new do
+          def count
+            if Bullet.start? && !proxy_association.is_a?(::ActiveRecord::Associations::ThroughAssociation)
+              Bullet::Detector::CounterCache.add_counter_cache(proxy_association.owner, proxy_association.reflection.name)
+            end
+            super
+          end
+        end
+      )
     end
   end
 end

--- a/lib/bullet/active_record52.rb
+++ b/lib/bullet/active_record52.rb
@@ -242,6 +242,17 @@ module Bullet
           end
         end
       )
+
+      ::ActiveRecord::Associations::CollectionProxy.prepend(
+        Module.new do
+          def count
+            if Bullet.start? && !proxy_association.is_a?(::ActiveRecord::Associations::ThroughAssociation)
+              Bullet::Detector::CounterCache.add_counter_cache(proxy_association.owner, proxy_association.reflection.name)
+            end
+            super
+          end
+        end
+      )
     end
   end
 end

--- a/lib/bullet/active_record60.rb
+++ b/lib/bullet/active_record60.rb
@@ -269,6 +269,17 @@ module Bullet
           end
         end
       )
+
+      ::ActiveRecord::Associations::CollectionProxy.prepend(
+        Module.new do
+          def count
+            if Bullet.start? && !proxy_association.is_a?(::ActiveRecord::Associations::ThroughAssociation)
+              Bullet::Detector::CounterCache.add_counter_cache(proxy_association.owner, proxy_association.reflection.name)
+            end
+            super
+          end
+        end
+      )
     end
   end
 end

--- a/lib/bullet/active_record61.rb
+++ b/lib/bullet/active_record61.rb
@@ -269,6 +269,17 @@ module Bullet
           end
         end
       )
+
+      ::ActiveRecord::Associations::CollectionProxy.prepend(
+        Module.new do
+          def count
+            if Bullet.start? && !proxy_association.is_a?(::ActiveRecord::Associations::ThroughAssociation)
+              Bullet::Detector::CounterCache.add_counter_cache(proxy_association.owner, proxy_association.reflection.name)
+            end
+            super
+          end
+        end
+      )
     end
   end
 end

--- a/lib/bullet/active_record70.rb
+++ b/lib/bullet/active_record70.rb
@@ -279,6 +279,17 @@ module Bullet
           end
         end
       )
+
+      ::ActiveRecord::Associations::CollectionProxy.prepend(
+        Module.new do
+          def count
+            if Bullet.start? && !proxy_association.is_a?(::ActiveRecord::Associations::ThroughAssociation)
+              Bullet::Detector::CounterCache.add_counter_cache(proxy_association.owner, proxy_association.reflection.name)
+            end
+            super
+          end
+        end
+      )
     end
   end
 end

--- a/lib/bullet/notification/counter_cache.rb
+++ b/lib/bullet/notification/counter_cache.rb
@@ -8,7 +8,7 @@ module Bullet
       end
 
       def title
-        'Need Counter Cache'
+        'Need Counter Cache with Active Record size'
       end
     end
   end

--- a/spec/bullet/notification/counter_cache_spec.rb
+++ b/spec/bullet/notification/counter_cache_spec.rb
@@ -8,7 +8,7 @@ module Bullet
       subject { CounterCache.new(Post, %i[comments votes]) }
 
       it { expect(subject.body).to eq('  Post => [:comments, :votes]') }
-      it { expect(subject.title).to eq('Need Counter Cache') }
+      it { expect(subject.title).to eq('Need Counter Cache with Active Record size') }
     end
   end
 end

--- a/spec/integration/counter_cache_spec.rb
+++ b/spec/integration/counter_cache_spec.rb
@@ -64,5 +64,29 @@ if !mongoid? && active_record?
         expect(Bullet.collected_counter_cache_notifications).to be_empty
       end
     end
+
+    describe 'with count' do
+      it 'should need counter cache' do
+        Country.all.each { |country| country.cities.count }
+        expect(Bullet.collected_counter_cache_notifications).not_to be_empty
+      end
+
+      it 'should notify even with counter cache' do
+        Person.all.each { |person| person.pets.count }
+        expect(Bullet.collected_counter_cache_notifications).not_to be_empty
+      end
+
+      if ActiveRecord::VERSION::MAJOR > 4
+        it 'should not need counter cache for has_many through' do
+          Client.all.each { |client| client.firms.count }
+          expect(Bullet.collected_counter_cache_notifications).to be_empty
+        end
+      else
+        it 'should need counter cache for has_many through' do
+          Client.all.each { |client| client.firms.count }
+          expect(Bullet.collected_counter_cache_notifications).not_to be_empty
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Just gauging interest here, as there may be a lot of considerations that I've missed. Generally people should use `size`, but if they use `count` the n+1 goes undetected. If you do want this in, we could backport it to older Rails versions.

Minimal example:
```ruby
class Blog < ApplicationRecord
  has_many :comments, dependent: :destroy
end

MAX = 5

# currently undetected
Blog.all.filter { |b| b.comments.count < MAX }

# gets detected as counter cache
Blog.all.filter { |b| b.comments.size < MAX }

# gets detected as n+1
Blog.all.filter { |b| b.comments.length < MAX }

# gets detected as n+1
Blog.all.filter { |b| b.comments.to_a.count < MAX }
```