### PR TITLE
Add note about enable reseting detectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Bullet.unused_eager_loading_enable = false
 Bullet.counter_cache_enable        = false
 ```
 
+Note: When calling `Bullet.enable`, all other detectors are reset to their defaults (`true`) and need reconfiguring.
+
 ## Safe list
 
 Sometimes Bullet may notify you of query problems you don't care to fix, or


### PR DESCRIPTION
It is not clear to many people that calling Bullet.enable resets all other detectors. This has been an open issue (https://github.com/flyerhzm/bullet/issues/481) for a number of years and doesn't look like being fixed soon. 

Adding a note in the README would provide a good solution to stop people losing time in the interim (I just lost an hour on this personally).

Thank you for your work with Bullet.