### PR TITLE
Alias `Bullet.enable?` to `enabled?`, and `Bullet.enable=` to `enabled=`

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -66,9 +66,13 @@ module Bullet
       end
     end
 
+    alias enabled= enable=
+
     def enable?
       !!@enable
     end
+
+    alias enabled? enable?
 
     # Rails.root might be nil if `railties` is a dependency on a project that does not use Rails
     def app_root

--- a/spec/bullet_spec.rb
+++ b/spec/bullet_spec.rb
@@ -38,6 +38,40 @@ describe Bullet, focused: true do
     end
   end
 
+  # Testing the aliases.
+  describe '#enabled' do
+    context 'enable Bullet' do
+      before do
+        # Bullet.enable
+        # Do nothing. Bullet has already been enabled for the whole test suite.
+      end
+
+      it 'should be enabled' do
+        expect(subject).to be_enabled
+      end
+
+      context 'disable Bullet' do
+        before { Bullet.enabled = false }
+
+        it 'should be disabled' do
+          expect(subject).to_not be_enabled
+        end
+
+        context 'enable Bullet again without patching again the orms' do
+          before do
+            expect(Bullet::Mongoid).not_to receive(:enabled) if defined?(Bullet::Mongoid)
+            expect(Bullet::ActiveRecord).not_to receive(:enabled) if defined?(Bullet::ActiveRecord)
+            Bullet.enabled = true
+          end
+
+          it 'should be enabled again' do
+            expect(subject).to be_enabled
+          end
+        end
+      end
+    end
+  end
+
   describe '#start?' do
     context 'when bullet is disabled' do
       before(:each) { Bullet.enable = false }


### PR DESCRIPTION
Perhaps a silly nitpick, but to me `Bullet.enabled?` reads a little bit more natural over currently provided `Bullet.enable?`, so I just made an alias in order to provide both APIs. Plus, added `Bullet.enabled=` alias for consistency.

Also, if it's acceptable, I'm happy to update the generator and documents to encourage the use of `enabled`.