### PR TITLE
Add support for `Content-Security-Policy-Report-Only` nonces

### DIFF
--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -135,7 +135,8 @@ module Bullet
     end
 
     def with_security_policy_nonce(headers)
-      matched = (headers['Content-Security-Policy'] || '').match(NONCE_MATCHER)
+      csp = headers['Content-Security-Policy'] || headers['Content-Security-Policy-Report-Only'] || ''
+      matched = csp.match(NONCE_MATCHER)
       nonce = matched[:nonce] if matched
 
       if nonce

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -155,6 +155,24 @@ module Bullet
             expect(headers['Content-Length']).to eq(size.to_s)
           end
 
+          it 'should include CSP nonce in inline script if console_enabled and a CSP (report only) is applied' do
+            allow(Bullet).to receive(:add_footer).at_least(:once).and_return(true)
+            expect(Bullet).to receive(:console_enabled?).and_return(true)
+            allow(middleware).to receive(:xhr_script).and_call_original
+
+            nonce = '+t9/wTlgG6xbHxXYUaDNzQ=='
+            app.headers = {
+              'Content-Type' => 'text/html',
+              'Content-Security-Policy-Report-Only' =>
+                "default-src 'self' https:; script-src 'self' https: 'nonce-#{nonce}'"
+            }
+
+            _, headers, response = middleware.call('Content-Type' => 'text/html')
+
+            size = 56 + middleware.send(:footer_note).length + middleware.send(:xhr_script, nonce).length
+            expect(headers['Content-Length']).to eq(size.to_s)
+          end
+
           it 'should change response body for html safe string if console_enabled is true' do
             expect(Bullet).to receive(:console_enabled?).and_return(true)
             app.response =


### PR DESCRIPTION
If using a "report only" CSP, bullet won't find/use the nonce thus will report bullet script tags as a policy violation. They will of course still execute, but with alerts for each script tag.

This change simply falls back to using the `Content-Security-Policy-Report-Only` header if the `Content-Security-Policy` header is not present, before falling back to an empty string.