### PR TITLE
Auto corrected by following Lint Ruby Lint/AmbiguousOperatorPrecedence

### DIFF
--- a/lib/bullet/stack_trace_filter.rb
+++ b/lib/bullet/stack_trace_filter.rb
@@ -13,8 +13,8 @@ module Bullet
       bundler_path = Bundler.bundle_path.to_s
       select_caller_locations(bullet_key) do |location|
         caller_path = location_as_path(location)
-        caller_path.include?(Bullet.app_root) && !caller_path.include?(vendor_root) &&
-          !caller_path.include?(bundler_path) || Bullet.stacktrace_includes.any? { |include_pattern|
+        (caller_path.include?(Bullet.app_root) && !caller_path.include?(vendor_root) &&
+          !caller_path.include?(bundler_path)) || Bullet.stacktrace_includes.any? { |include_pattern|
                                                    pattern_matches?(location, include_pattern)
                                                  }
       end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/AmbiguousOperatorPrecedence

Click [here](https://awesomecode.io/repos/flyerhzm/bullet/lint_configs/ruby/123773) to configure it on awesomecode.io