### PR TITLE
Auto corrected by following Lint Ruby Lint/UnusedMethodArgument

### DIFF
--- a/lib/bullet/mongoid7x.rb
+++ b/lib/bullet/mongoid7x.rb
@@ -20,7 +20,7 @@ module Bullet
           end
         end
 
-        def each(&block)
+        def each()
           return to_enum unless block_given?
 
           first_document = nil

--- a/lib/bullet/rack.rb
+++ b/lib/bullet/rack.rb
@@ -85,7 +85,7 @@ module Bullet
       headers['Content-Type'] == 'text/event-stream'
     end
 
-    def html_request?(headers, response)
+    def html_request?(headers, _response)
       headers['Content-Type']&.include?('text/html')
     end
 


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/UnusedMethodArgument

Click [here](https://awesomecode.io/repos/flyerhzm/bullet/lint_configs/ruby/10901) to configure it on awesomecode.io