### PR TITLE
fix: Support ActiveRecord 7.1 composite primary keys

### DIFF
--- a/lib/bullet/ext/object.rb
+++ b/lib/bullet/ext/object.rb
@@ -9,12 +9,21 @@ class Object
     return if respond_to?(:persisted?) && !persisted?
 
     if self.class.respond_to?(:primary_keys) && self.class.primary_keys
-      self.class.primary_keys.map { |primary_key| send primary_key }
-          .join(',')
+      primary_key = self.class.primary_keys
     elsif self.class.respond_to?(:primary_key) && self.class.primary_key
-      send self.class.primary_key
+      primary_key = self.class.primary_key
     else
-      id
+      primary_key = :id
     end
+
+    bullet_join_potential_composite_primary_key(primary_key)
+  end
+
+  private
+
+  def bullet_join_potential_composite_primary_key(primary_keys)
+    return send(primary_keys) unless primary_keys.is_a?(Enumerable)
+
+    primary_keys.map { |primary_key| send primary_key }.join(',')
   end
 end

--- a/spec/bullet/ext/object_spec.rb
+++ b/spec/bullet/ext/object_spec.rb
@@ -30,9 +30,15 @@ describe Object do
       Post.primary_key = 'id'
     end
 
-    it 'should return value for multiple primary keys' do
+    it 'should return value for multiple primary keys from the composite_primary_key gem' do
       post = Post.first
       allow(Post).to receive(:primary_keys).and_return(%i[category_id writer_id])
+      expect(post.bullet_primary_key_value).to eq("#{post.category_id},#{post.writer_id}")
+    end
+
+    it 'should return value for multiple primary keys from ActiveRecord 7.1' do
+      post = Post.first
+      allow(Post).to receive(:primary_key).and_return(%i[category_id writer_id])
       expect(post.bullet_primary_key_value).to eq("#{post.category_id},#{post.writer_id}")
     end
 


### PR DESCRIPTION
ActiveRecord 7.1 added first-party support for composite primary keys, which changed the way the `primary_key` method behaves; specifically, in cases where a model or table has a composite primary key, this will return an array of attributes rather than just one.

Given this gem already has support for composite primary keys through the `composite_primary_keys` gem, I just extracted out the work done there to support Rails 7.1's approach.

Closes #685.