### PR TITLE
fix mongoid8

### DIFF
--- a/lib/bullet/mongoid8x.rb
+++ b/lib/bullet/mongoid8x.rb
@@ -8,14 +8,14 @@ module Bullet
         alias_method :origin_each, :each
         alias_method :origin_eager_load, :eager_load
 
-        def first(opts = {})
-          result = origin_first(opts)
+        def first(limit = nil)
+          result = origin_first(limit)
           Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
           result
         end
 
-        def last(opts = {})
-          result = origin_last(opts)
+        def last(limit = nil)
+          result = origin_last(limit)
           Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
           result
         end


### PR DESCRIPTION
* make `first` and `last` signatures compatible with mongoid 8 see https://www.mongodb.com/docs/mongoid/current/release-notes/mongoid-8.0/#-id_sort-option-on--first-last-removed
* `first` and `last` only take a limit value rather than an option set

fixes https://github.com/flyerhzm/bullet/issues/689