### PR TITLE
Make core extensions cleaner with refinements

### DIFF
--- a/lib/bullet/detector/association.rb
+++ b/lib/bullet/detector/association.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using Bullet::Ext::Object
+
 module Bullet
   module Detector
     class Association < Base

--- a/lib/bullet/detector/counter_cache.rb
+++ b/lib/bullet/detector/counter_cache.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using Bullet::Ext::Object
+
 module Bullet
   module Detector
     class CounterCache < Base

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using Bullet::Ext::Object
+
 module Bullet
   module Detector
     class NPlusOneQuery < Association

--- a/lib/bullet/detector/unused_eager_loading.rb
+++ b/lib/bullet/detector/unused_eager_loading.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+using Bullet::Ext::Object
 using Bullet::Ext::String
 
 module Bullet

--- a/lib/bullet/detector/unused_eager_loading.rb
+++ b/lib/bullet/detector/unused_eager_loading.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using Bullet::Ext::String
+
 module Bullet
   module Detector
     class UnusedEagerLoading < Association

--- a/lib/bullet/ext/object.rb
+++ b/lib/bullet/ext/object.rb
@@ -1,30 +1,36 @@
 # frozen_string_literal: true
 
-class Object
-  def bullet_key
-    "#{self.class}:#{bullet_primary_key_value}"
-  end
+module Bullet
+  module Ext
+    module Object
+      refine ::Object do
+        def bullet_key
+          "#{self.class}:#{bullet_primary_key_value}"
+        end
 
-  def bullet_primary_key_value
-    return if respond_to?(:persisted?) && !persisted?
+        def bullet_primary_key_value
+          return if respond_to?(:persisted?) && !persisted?
 
-    if self.class.respond_to?(:primary_keys) && self.class.primary_keys
-      primary_key = self.class.primary_keys
-    elsif self.class.respond_to?(:primary_key) && self.class.primary_key
-      primary_key = self.class.primary_key
-    else
-      primary_key = :id
+          if self.class.respond_to?(:primary_keys) && self.class.primary_keys
+            primary_key = self.class.primary_keys
+          elsif self.class.respond_to?(:primary_key) && self.class.primary_key
+            primary_key = self.class.primary_key
+          else
+            primary_key = :id
+          end
+
+          bullet_join_potential_composite_primary_key(primary_key)
+        end
+
+        private
+
+        def bullet_join_potential_composite_primary_key(primary_keys)
+          return send(primary_keys) unless primary_keys.is_a?(Enumerable)
+
+          primary_keys.map { |primary_key| send primary_key }
+                      .join(',')
+        end
+      end
     end
-
-    bullet_join_potential_composite_primary_key(primary_key)
-  end
-
-  private
-
-  def bullet_join_potential_composite_primary_key(primary_keys)
-    return send(primary_keys) unless primary_keys.is_a?(Enumerable)
-
-    primary_keys.map { |primary_key| send primary_key }
-                .join(',')
   end
 end

--- a/lib/bullet/ext/string.rb
+++ b/lib/bullet/ext/string.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
-class String
-  def bullet_class_name
-    sub(/:[^:]*?$/, '')
+module Bullet
+  module Ext
+    module String
+      refine ::String do
+        def bullet_class_name
+          sub(/:[^:]*?$/, '')
+        end
+      end
+    end
   end
 end

--- a/lib/bullet/registry/object.rb
+++ b/lib/bullet/registry/object.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using Bullet::Ext::String
+
 module Bullet
   module Registry
     class Object < Base

--- a/lib/bullet/registry/object.rb
+++ b/lib/bullet/registry/object.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+using Bullet::Ext::Object
 using Bullet::Ext::String
 
 module Bullet

--- a/lib/bullet/stack_trace_filter.rb
+++ b/lib/bullet/stack_trace_filter.rb
@@ -2,6 +2,8 @@
 
 require "bundler"
 
+using Bullet::Ext::Object
+
 module Bullet
   module StackTraceFilter
     VENDOR_PATH = '/vendor'

--- a/spec/bullet/detector/association_spec.rb
+++ b/spec/bullet/detector/association_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext::Object
+
 module Bullet
   module Detector
     describe Association do

--- a/spec/bullet/detector/counter_cache_spec.rb
+++ b/spec/bullet/detector/counter_cache_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext::Object
+
 module Bullet
   module Detector
     describe CounterCache do

--- a/spec/bullet/detector/n_plus_one_query_spec.rb
+++ b/spec/bullet/detector/n_plus_one_query_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext::Object
+
 module Bullet
   module Detector
     describe NPlusOneQuery do

--- a/spec/bullet/detector/unused_eager_loading_spec.rb
+++ b/spec/bullet/detector/unused_eager_loading_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext::Object
+
 module Bullet
   module Detector
     describe UnusedEagerLoading do

--- a/spec/bullet/ext/object_spec.rb
+++ b/spec/bullet/ext/object_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext::Object
+
 describe Object do
   context 'bullet_key' do
     it 'should return class and id composition' do

--- a/spec/bullet/ext/string_spec.rb
+++ b/spec/bullet/ext/string_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext::String
+
 describe String do
   context 'bullet_class_name' do
     it 'should only return class name' do

--- a/spec/bullet/registry/object_spec.rb
+++ b/spec/bullet/registry/object_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Bullet::Ext::Object
+
 module Bullet
   module Registry
     describe Object do

--- a/spec/support/bullet_ext.rb
+++ b/spec/support/bullet_ext.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using Bullet::Ext::Object
+
 module Bullet
   def self.collected_notifications_of_class(notification_class)
     Bullet.notification_collector.collection.select { |notification| notification.is_a? notification_class }


### PR DESCRIPTION
This gem monkey-patches Object class and String class with the following four methods for the gem internal use,

Object#bullet_key
Object#bullet_primary_key_value
Object#bullet_join_potential_composite_primary_key
String#bullet_class_name

and these methods are globally polluting every Object in the whole Ruby process.

This kind of monkey-patching is a dangerous approach and should be avoided in a gem that is usually bundled only in development/test, since it may become a cause of weird bugs that happen only on production env.

So, here's a patch that encapsulates these monkey-patches inside this gem by rewriting the core-exts to use refinements.

Note that this can be an incompatible change for those who use these methods from their application code. I can hardly imagine such a use case, but in such case, they may have to add `using` calls to their application.