### PR TITLE
Support ActiveRecord 8.0.0.alpha

### DIFF
--- a/Gemfile.rails-main
+++ b/Gemfile.rails-main
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "rails", github: "rails/rails", branch: "main"
+gem 'sqlite3'
+gem 'activerecord-jdbcsqlite3-adapter', platforms: [:jruby]
+gem 'activerecord-import'
+
+gem "rspec"

--- a/lib/bullet/active_record_main.rb
+++ b/lib/bullet/active_record_main.rb
@@ -1,0 +1,1 @@
+require_relative 'active_record72'

--- a/lib/bullet/dependency.rb
+++ b/lib/bullet/dependency.rb
@@ -35,6 +35,8 @@ module Bullet
             'active_record71'
           elsif active_record72?
             'active_record72'
+          elsif active_record_main?
+            'active_record_main'
           else
             raise "Bullet does not support active_record #{::ActiveRecord::VERSION::STRING} yet"
           end
@@ -74,6 +76,10 @@ module Bullet
 
     def active_record7?
       active_record? && ::ActiveRecord::VERSION::MAJOR == 7
+    end
+
+    def active_record_main?
+      active_record? && ::ActiveRecord::VERSION::MAJOR == 8
     end
 
     def active_record40?

--- a/lib/bullet/version.rb
+++ b/lib/bullet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bullet
-  VERSION = '7.2.0'
+  VERSION = '8.0.0.alpha'
 end

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,6 @@
 #bundle update rails && bundle exec rspec spec
 #BUNDLE_GEMFILE=Gemfile.mongoid bundle update mongoid && BUNDLE_GEMFILE=Gemfile.mongoid bundle exec rspec spec
+BUNDLE_GEMFILE=Gemfile.rails-main bundle && BUNDLE_GEMFILE=Gemfile.rails-main bundle exec rspec spec
 BUNDLE_GEMFILE=Gemfile.rails-7.2 bundle && BUNDLE_GEMFILE=Gemfile.rails-7.2 bundle exec rspec spec
 BUNDLE_GEMFILE=Gemfile.rails-7.1 bundle && BUNDLE_GEMFILE=Gemfile.rails-7.1 bundle exec rspec spec
 BUNDLE_GEMFILE=Gemfile.rails-7.0 bundle && BUNDLE_GEMFILE=Gemfile.rails-7.0 bundle exec rspec spec


### PR DESCRIPTION
Rails v8 may be a while away from release, but I made this PR to support ActiveRecord 8.0.0.alpha, duplicating the same one made for 7.2.0 in #707