### PR TITLE
Store global objects into thread-local variables

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -147,36 +147,48 @@ module Bullet
       puts "[Bullet][#{title}] #{message}" if ENV['BULLET_DEBUG'] == 'true'
     end
 
-    def thread_local_data
-      Thread.current.thread_variable_get(:bullet) || Thread.current.thread_variable_set(:bullet, {})
-    end
-
     def start_request
-      thread_local_data[:bullet_start] = true
-      thread_local_data[:bullet_notification_collector] = Bullet::NotificationCollector.new
+      Thread.current.thread_variable_set(:bullet_start, true)
+      Thread.current.thread_variable_set(:bullet_notification_collector, Bullet::NotificationCollector.new)
 
-      thread_local_data[:bullet_object_associations] = Bullet::Registry::Base.new
-      thread_local_data[:bullet_call_object_associations] = Bullet::Registry::Base.new
-      thread_local_data[:bullet_possible_objects] = Bullet::Registry::Object.new
-      thread_local_data[:bullet_impossible_objects] = Bullet::Registry::Object.new
-      thread_local_data[:bullet_inversed_objects] = Bullet::Registry::Base.new
-      thread_local_data[:bullet_eager_loadings] = Bullet::Registry::Association.new
-      thread_local_data[:bullet_call_stacks] = Bullet::Registry::CallStack.new
+      Thread.current.thread_variable_set(:bullet_object_associations, Bullet::Registry::Base.new)
+      Thread.current.thread_variable_set(:bullet_call_object_associations, Bullet::Registry::Base.new)
+      Thread.current.thread_variable_set(:bullet_possible_objects, Bullet::Registry::Object.new)
+      Thread.current.thread_variable_set(:bullet_impossible_objects, Bullet::Registry::Object.new)
+      Thread.current.thread_variable_set(:bullet_inversed_objects, Bullet::Registry::Base.new)
+      Thread.current.thread_variable_set(:bullet_eager_loadings, Bullet::Registry::Association.new)
+      Thread.current.thread_variable_set(:bullet_call_stacks, Bullet::Registry::CallStack.new)
 
-      thread_local_data[:bullet_counter_possible_objects] ||= Bullet::Registry::Object.new
-      thread_local_data[:bullet_counter_impossible_objects] ||= Bullet::Registry::Object.new
+      unless Thread.current.thread_variable_get(:bullet_counter_possible_objects)
+        Thread.current.thread_variable_set(:bullet_counter_possible_objects, Bullet::Registry::Object.new)
+      end
+
+      unless Thread.current.thread_variable_get(:bullet_counter_impossible_objects)
+        Thread.current.thread_variable_set(:bullet_counter_impossible_objects, Bullet::Registry::Object.new)
+      end
     end
 
     def end_request
-      Thread.current.thread_variable_set(:bullet, nil)
+      Thread.current.thread_variable_set(:bullet_start, nil)
+      Thread.current.thread_variable_set(:bullet_notification_collector, nil)
+
+      Thread.current.thread_variable_set(:bullet_object_associations, nil)
+      Thread.current.thread_variable_set(:bullet_call_object_associations, nil)
+      Thread.current.thread_variable_set(:bullet_possible_objects, nil)
+      Thread.current.thread_variable_set(:bullet_impossible_objects, nil)
+      Thread.current.thread_variable_set(:bullet_inversed_objects, nil)
+      Thread.current.thread_variable_set(:bullet_eager_loadings, nil)
+
+      Thread.current.thread_variable_set(:bullet_counter_possible_objects, nil)
+      Thread.current.thread_variable_set(:bullet_counter_impossible_objects, nil)
     end
 
     def start?
-      enable? && thread_local_data[:bullet_start]
+      enable? && Thread.current.thread_variable_get(:bullet_start)
     end
 
     def notification_collector
-      thread_local_data[:bullet_notification_collector]
+      Thread.current.thread_variable_get(:bullet_notification_collector)
     end
 
     def notification?

--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -147,43 +147,36 @@ module Bullet
       puts "[Bullet][#{title}] #{message}" if ENV['BULLET_DEBUG'] == 'true'
     end
 
+    def thread_local_data
+      Thread.current.thread_variable_get(:bullet) || Thread.current.thread_variable_set(:bullet, {})
+    end
+
     def start_request
-      Thread.current[:bullet_start] = true
-      Thread.current[:bullet_notification_collector] = Bullet::NotificationCollector.new
+      thread_local_data[:bullet_start] = true
+      thread_local_data[:bullet_notification_collector] = Bullet::NotificationCollector.new
 
-      Thread.current[:bullet_object_associations] = Bullet::Registry::Base.new
-      Thread.current[:bullet_call_object_associations] = Bullet::Registry::Base.new
-      Thread.current[:bullet_possible_objects] = Bullet::Registry::Object.new
-      Thread.current[:bullet_impossible_objects] = Bullet::Registry::Object.new
-      Thread.current[:bullet_inversed_objects] = Bullet::Registry::Base.new
-      Thread.current[:bullet_eager_loadings] = Bullet::Registry::Association.new
-      Thread.current[:bullet_call_stacks] = Bullet::Registry::CallStack.new
+      thread_local_data[:bullet_object_associations] = Bullet::Registry::Base.new
+      thread_local_data[:bullet_call_object_associations] = Bullet::Registry::Base.new
+      thread_local_data[:bullet_possible_objects] = Bullet::Registry::Object.new
+      thread_local_data[:bullet_impossible_objects] = Bullet::Registry::Object.new
+      thread_local_data[:bullet_inversed_objects] = Bullet::Registry::Base.new
+      thread_local_data[:bullet_eager_loadings] = Bullet::Registry::Association.new
+      thread_local_data[:bullet_call_stacks] = Bullet::Registry::CallStack.new
 
-      Thread.current[:bullet_counter_possible_objects] ||= Bullet::Registry::Object.new
-      Thread.current[:bullet_counter_impossible_objects] ||= Bullet::Registry::Object.new
+      thread_local_data[:bullet_counter_possible_objects] ||= Bullet::Registry::Object.new
+      thread_local_data[:bullet_counter_impossible_objects] ||= Bullet::Registry::Object.new
     end
 
     def end_request
-      Thread.current[:bullet_start] = nil
-      Thread.current[:bullet_notification_collector] = nil
-
-      Thread.current[:bullet_object_associations] = nil
-      Thread.current[:bullet_call_object_associations] = nil
-      Thread.current[:bullet_possible_objects] = nil
-      Thread.current[:bullet_impossible_objects] = nil
-      Thread.current[:bullet_inversed_objects] = nil
-      Thread.current[:bullet_eager_loadings] = nil
-
-      Thread.current[:bullet_counter_possible_objects] = nil
-      Thread.current[:bullet_counter_impossible_objects] = nil
+      Thread.current.thread_variable_set(:bullet, nil)
     end
 
     def start?
-      enable? && Thread.current[:bullet_start]
+      enable? && thread_local_data[:bullet_start]
     end
 
     def notification_collector
-      Thread.current[:bullet_notification_collector]
+      thread_local_data[:bullet_notification_collector]
     end
 
     def notification?

--- a/lib/bullet/detector/association.rb
+++ b/lib/bullet/detector/association.rb
@@ -34,7 +34,7 @@ module Bullet
         # that the objects may cause N+1 query.
         # e.g. { Post => ["Post:1", "Post:2"] }
         def possible_objects
-          Thread.current[:bullet_possible_objects]
+          Bullet.thread_local_data[:bullet_possible_objects]
         end
 
         # impossible_objects keep the class to objects relationships
@@ -43,7 +43,7 @@ module Bullet
         # if find collection returns only one object, then the object is impossible object,
         # impossible_objects are used to avoid treating 1+1 query to N+1 query.
         def impossible_objects
-          Thread.current[:bullet_impossible_objects]
+          Bullet.thread_local_data[:bullet_impossible_objects]
         end
 
         private
@@ -54,7 +54,7 @@ module Bullet
         # the object_associations keep all associations that may be or may no be
         # unpreload associations or unused preload associations.
         def object_associations
-          Thread.current[:bullet_object_associations]
+          Bullet.thread_local_data[:bullet_object_associations]
         end
 
         # call_object_associations keep the object relationships
@@ -62,27 +62,27 @@ module Bullet
         # e.g. { "Post:1" => [:comments] }
         # they are used to detect unused preload associations.
         def call_object_associations
-          Thread.current[:bullet_call_object_associations]
+          Bullet.thread_local_data[:bullet_call_object_associations]
         end
 
         # inversed_objects keeps object relationships
         # that association is inversed.
         # e.g. { "Comment:1" => ["post"] }
         def inversed_objects
-          Thread.current[:bullet_inversed_objects]
+          Bullet.thread_local_data[:bullet_inversed_objects]
         end
 
         # eager_loadings keep the object relationships
         # that the associations are preloaded by find :include.
         # e.g. { ["Post:1", "Post:2"] => [:comments, :user] }
         def eager_loadings
-          Thread.current[:bullet_eager_loadings]
+          Bullet.thread_local_data[:bullet_eager_loadings]
         end
 
         # cal_stacks keeps stacktraces where querie-objects were called from.
         # e.g. { 'Object:111' => [SomeProject/app/controllers/...] }
         def call_stacks
-          Thread.current[:bullet_call_stacks]
+          Bullet.thread_local_data[:bullet_call_stacks]
         end
       end
     end

--- a/lib/bullet/detector/association.rb
+++ b/lib/bullet/detector/association.rb
@@ -34,7 +34,7 @@ module Bullet
         # that the objects may cause N+1 query.
         # e.g. { Post => ["Post:1", "Post:2"] }
         def possible_objects
-          Bullet.thread_local_data[:bullet_possible_objects]
+          Thread.current.thread_variable_get(:bullet_possible_objects)
         end
 
         # impossible_objects keep the class to objects relationships
@@ -43,7 +43,7 @@ module Bullet
         # if find collection returns only one object, then the object is impossible object,
         # impossible_objects are used to avoid treating 1+1 query to N+1 query.
         def impossible_objects
-          Bullet.thread_local_data[:bullet_impossible_objects]
+          Thread.current.thread_variable_get(:bullet_impossible_objects)
         end
 
         private
@@ -54,7 +54,7 @@ module Bullet
         # the object_associations keep all associations that may be or may no be
         # unpreload associations or unused preload associations.
         def object_associations
-          Bullet.thread_local_data[:bullet_object_associations]
+          Thread.current.thread_variable_get(:bullet_object_associations)
         end
 
         # call_object_associations keep the object relationships
@@ -62,27 +62,27 @@ module Bullet
         # e.g. { "Post:1" => [:comments] }
         # they are used to detect unused preload associations.
         def call_object_associations
-          Bullet.thread_local_data[:bullet_call_object_associations]
+          Thread.current.thread_variable_get(:bullet_call_object_associations)
         end
 
         # inversed_objects keeps object relationships
         # that association is inversed.
         # e.g. { "Comment:1" => ["post"] }
         def inversed_objects
-          Bullet.thread_local_data[:bullet_inversed_objects]
+          Thread.current.thread_variable_get(:bullet_inversed_objects)
         end
 
         # eager_loadings keep the object relationships
         # that the associations are preloaded by find :include.
         # e.g. { ["Post:1", "Post:2"] => [:comments, :user] }
         def eager_loadings
-          Bullet.thread_local_data[:bullet_eager_loadings]
+          Thread.current.thread_variable_get(:bullet_eager_loadings)
         end
 
         # cal_stacks keeps stacktraces where querie-objects were called from.
         # e.g. { 'Object:111' => [SomeProject/app/controllers/...] }
         def call_stacks
-          Bullet.thread_local_data[:bullet_call_stacks]
+          Thread.current.thread_variable_get(:bullet_call_stacks)
         end
       end
     end

--- a/lib/bullet/detector/counter_cache.rb
+++ b/lib/bullet/detector/counter_cache.rb
@@ -44,11 +44,11 @@ module Bullet
         end
 
         def possible_objects
-          Thread.current[:bullet_counter_possible_objects]
+          Bullet.thread_local_data[:bullet_counter_possible_objects]
         end
 
         def impossible_objects
-          Thread.current[:bullet_counter_impossible_objects]
+          Bullet.thread_local_data[:bullet_counter_impossible_objects]
         end
 
         private

--- a/lib/bullet/detector/counter_cache.rb
+++ b/lib/bullet/detector/counter_cache.rb
@@ -44,11 +44,11 @@ module Bullet
         end
 
         def possible_objects
-          Bullet.thread_local_data[:bullet_counter_possible_objects]
+          Thread.current.thread_variable_get(:bullet_counter_possible_objects)
         end
 
         def impossible_objects
-          Bullet.thread_local_data[:bullet_counter_impossible_objects]
+          Thread.current.thread_variable_get(:bullet_counter_impossible_objects)
         end
 
         private

--- a/spec/integration/active_record/association_spec.rb
+++ b/spec/integration/active_record/association_spec.rb
@@ -113,6 +113,20 @@ if active_record?
 
         expect(Bullet::Detector::Association).to be_detecting_unpreloaded_association_for(Post, :comments)
       end
+
+      context 'inside Fiber' do
+        it 'should detect non preload post => comments' do
+          fiber = Fiber.new do
+            Post.all.each { |post| post.comments.map(&:name) }
+          end
+          fiber.resume
+
+          Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
+          expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
+
+          expect(Bullet::Detector::Association).to be_detecting_unpreloaded_association_for(Post, :comments)
+        end
+      end
     end
 
     context 'category => posts => comments' do


### PR DESCRIPTION
## Context

Bullet stores global objects into fiber-local variables before each request, uses these global objects to collect all N+1 queries and later shows all collected problems based on these global objects result. This approach works well until someone don't try to run his code inside Fiber like this

```ruby
class PostsController < ApplicationController
  def index
    fiber = ::Fiber.new do
      Post.find_each do |post|
        post.comments.each do |comment|
          comment.name
        end
      end
    end

    fiber.resume
  end
end
```

In that case bullet warning is not shown because all global objects are stored as fiber-local variables for current Fiber and not passed to all new Fibers

## Decision

The easiest way is to store bullet objects into thread-local variables instead: https://ruby-doc.org/core-2.6/Thread.html#class-Thread-label-Fiber-local+vs.+Thread-local

## Changes

1. move Bullet objects to thread-local variables
2. combine variables into single thread local variable

## Notes

this problem can easily occur even when rails app does not use fibers explicitly but instead uses some 3rd party libraries like  https://github.com/dry-rb/dry-effects/issues/82
