### PR TITLE
Fix flaky spec

### DIFF
--- a/spec/integration/active_record/association_spec.rb
+++ b/spec/integration/active_record/association_spec.rb
@@ -694,7 +694,7 @@ if active_record?
   describe Bullet::Detector::Association, 'query immediately after creation' do
     context 'with save' do
       context 'document => children' do
-        it 'should not detect non preload associations' do
+        around do |example|
           document1 = Document.new
           document1.children.build
           document1.save
@@ -705,7 +705,15 @@ if active_record?
 
           document1.children.each.first
 
+          example.run
+
+          document1.children.destroy_all
+          document1.destroy
+        end
+
+        it 'should not detect non preload associations' do
           Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
+
           expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
 
           expect(Bullet::Detector::Association).to be_completely_preloading_associations
@@ -715,7 +723,7 @@ if active_record?
 
     context 'with save!' do
       context 'document => children' do
-        it 'should not detect non preload associations' do
+        around do |example|
           document1 = Document.new
           document1.children.build
           document1.save!
@@ -726,6 +734,13 @@ if active_record?
 
           document1.children.each.first
 
+          example.run
+
+          document1.children.destroy_all
+          document1.destroy
+        end
+
+        it 'should not detect non preload associations' do
           Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
           expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
 

--- a/spec/integration/active_record/association_spec.rb
+++ b/spec/integration/active_record/association_spec.rb
@@ -348,15 +348,23 @@ if active_record?
         expect(Bullet::Detector::Association).to be_completely_preloading_associations
       end
 
-      it 'should not detect newly assigned object in an after_save' do
-        new_post = Post.new(category: Category.first)
+      context 'in an after_save' do
+        around do |example|
+          new_post = Post.new(category: Category.first)
+          new_post.trigger_after_save = true
+          new_post.save!
 
-        new_post.trigger_after_save = true
-        new_post.save!
-        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
-        expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
+          example.run
 
-        expect(Bullet::Detector::Association).to be_completely_preloading_associations
+          new_post.destroy
+        end
+
+        it 'should not detect newly assigned object' do
+          Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
+          expect(Bullet::Detector::Association).not_to be_has_unused_preload_associations
+
+          expect(Bullet::Detector::Association).to be_completely_preloading_associations
+        end
       end
     end
 


### PR DESCRIPTION
## Context

There were some tests with data leaked out to other tests

```ruby
BUNDLE_GEMFILE=Gemfile.rails-7.2 bundle && BUNDLE_GEMFILE=Gemfile.rails-7.2 bundle exec rspec './spec/integration/active_record/association_spec.rb[1:5:1,2:1:6]' --seed 18477

Bundle complete! 7 Gemfile dependencies, 73 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
Run options: include {:focus=>true, :ids=>{"./spec/integration/active_record/association_spec.rb"=>["1:5:1", "2:1:6"]}}

Randomized with seed 18477
.F

Failures:

  1) Bullet::Detector::Association has_many category => posts => writer should not detect unused preload associations
     Failure/Error: post.writer.name

     NoMethodError:
       undefined method `name' for nil
     # ./spec/integration/active_record/association_spec.rb:264:in `block (4 levels) in <top (required)>'
     # ./spec/integration/active_record/association_spec.rb:262:in `map'
     # ./spec/integration/active_record/association_spec.rb:262:in `block (3 levels) in <top (required)>'

Finished in 0.15346 seconds (files took 0.48094 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/integration/active_record/association_spec.rb:260 # Bullet::Detector::Association has_many category => posts => writer should not detect unused preload associations
```

## Changes

1. Bullet::Detector::Association: destroy Post created during  `in an after_save`
2. Bullet::Detector::Association: destroy Documents created during `document => children`