### PR TITLE
Memoize call_stack registry for same key entry

### DIFF
--- a/lib/bullet/registry/call_stack.rb
+++ b/lib/bullet/registry/call_stack.rb
@@ -5,7 +5,7 @@ module Bullet
     class CallStack < Base
       # remembers found association backtrace
       def add(key)
-        @registry[key] = Thread.current.backtrace
+        @registry[key] ||= Thread.current.backtrace
       end
     end
   end


### PR DESCRIPTION
With this simple trick, a local rails server with less than a dozen SQL  queries using AR drastically reduces the amount of memory allocated by  bullet.

before:
```
allocated memory by gem
-----------------------------------
    796102  activesupport-7.2.1
    726428  bullet/lib
```

after:
```
allocated memory by gem
-----------------------------------
    794350  activesupport-7.2.1
    313180  sprockets-4.2.1
    259688  activerecord-7.2.1
    204936  bullet/lib
```

Using the patched perf/benchmark.rb file to work with sqlite instead of  mysql, I saw reproductible numbers:

main
```
Querying & Iterating 1000 Posts with 10000 Comments and 100 Users                            
user     system      total        real
14.503545   0.638605  15.142150 ( 15.201747)
```

patch
```
Querying & Iterating 1000 Posts with 10000 Comments and 100 Users

user     system      total        real
12.781415   0.664749  13.446164 ( 13.533855)
```