### PR TITLE
Support warnings with Turbo Streams/Frames

### DIFF
--- a/spec/bullet/detector/n_plus_one_query_spec.rb
+++ b/spec/bullet/detector/n_plus_one_query_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'ostruct'
 
 using Bullet::Ext::Object
 

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -7,29 +7,29 @@ module Bullet
     let(:middleware) { Bullet::Rack.new app }
     let(:app) { Support::AppDouble.new }
 
-    context '#html_request?' do
+    context '#html_response?' do
       it 'should be true if Content-Type is text/html and http body contains html tag' do
         headers = { 'Content-Type' => 'text/html' }
         response = double(body: '<html><head></head><body></body></html>')
-        expect(middleware).to be_html_request(headers, response)
+        expect(middleware).to be_html_response(headers, response)
       end
 
       it 'should be true if Content-Type is text/html and http body contains html tag with attributes' do
         headers = { 'Content-Type' => 'text/html' }
         response = double(body: "<html attr='hello'><head></head><body></body></html>")
-        expect(middleware).to be_html_request(headers, response)
+        expect(middleware).to be_html_response(headers, response)
       end
 
       it 'should be false if there is no Content-Type header' do
         headers = {}
         response = double(body: '<html><head></head><body></body></html>')
-        expect(middleware).not_to be_html_request(headers, response)
+        expect(middleware).not_to be_html_response(headers, response)
       end
 
       it 'should be false if Content-Type is javascript' do
         headers = { 'Content-Type' => 'text/javascript' }
         response = double(body: '<html><head></head><body></body></html>')
-        expect(middleware).not_to be_html_request(headers, response)
+        expect(middleware).not_to be_html_response(headers, response)
       end
     end
 

--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -335,5 +335,53 @@ module Bullet
       rescue LoadError
       end
     end
+
+    context '#turbo_stream_response?' do
+      it 'should be true if Content-Type is text/vnd.turbo-stream.html' do
+        headers = { 'Content-Type' => 'text/vnd.turbo-stream.html' }
+        expect(middleware).to be_turbo_stream_response(headers, nil)
+      end
+
+      it 'should be false if Content-Type is text/html' do
+        headers = { 'Content-Type' => 'text/html' }
+        expect(middleware).not_to be_turbo_stream_response(headers, nil)
+      end
+    end
+
+    context '#turbo_frame_request?' do
+      it 'should be true if request is a turbo-frame request' do
+        request = double(env: { 'HTTP_TURBO_FRAME' => 'frame-id' })
+        expect(middleware).to be_turbo_frame_request(request)
+      end
+
+      it 'should be false if request is not a turbo-frame request' do
+        request = double(env: {})
+        expect(middleware).not_to be_turbo_frame_request(request)
+      end
+    end
+
+    context '#append_to_turbo_frame_body' do
+      it 'should append content to turbo frame body' do
+        request = double(env: { 'HTTP_TURBO_FRAME' => 'frame-id' })
+        response_body = '<turbo-frame id="frame-id">test</turbo-frame>'
+        content = '<div>content</div>'
+        expect(middleware.append_to_turbo_frame_body(request, response_body, content)).to eq('<turbo-frame id="frame-id">test<div>content</div></turbo-frame>')
+      end
+
+      it 'should append content to turbo frame body with single quotes' do
+        request = double(env: { 'HTTP_TURBO_FRAME' => 'frame-id' })
+        response_body = "<turbo-frame id='frame-id'>test</turbo-frame>"
+        content = '<div>content</div>'
+        expect(middleware.append_to_turbo_frame_body(request, response_body, content)).to eq("<turbo-frame id='frame-id'>test<div>content</div></turbo-frame>")
+      end
+    end
+
+    context '#append_to_turbo_stream_body' do
+      it 'should append content to turbo stream body' do
+        response_body = '<turbo-stream action="update"><template>test</template></turbo-stream>'
+        content = '<div>content</div>'
+        expect(middleware.append_to_turbo_stream_body(response_body, content)).to eq('<turbo-stream action="update"><template>test<div>content</div></template></turbo-stream>')
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves #724 

## Purpose
To provide bullet warnings in rails applications that use Turbo Streams and Turbo Frames.

## Approach
Use the rack middleware to detect if a request is related to Turbo and inject the Bullet warnings appropriately.

### Note

This does not add support for the javascript `alert()`. A quick and dirty hack to make the `alert()` show up is to add script like this to to the `<head>` of my `application.html.erb` (although the messages aren't quite as nice looking as the alerts from uniform_notifier):
```erb
    <% if Rails.env.development? %>
    <script>
      function alertIfBulletWarning(bulletFooterDiv) {
        if (bulletFooterDiv) {
            const textWithoutSpan = Array.from(bulletFooterDiv.childNodes)
  .filter(node => node.nodeType === Node.TEXT_NODE)
  .map(node => node.textContent.trim())
  .join(' ');
            alert(textWithoutSpan);
          }
      }
      document.addEventListener("turbo:frame-render", function(event) {
        event.detail.fetchResponse.responseHTML.then(html => {
          const bulletFooterDiv = document.querySelector('details#bullet-footer > div');
          alertIfBulletWarning(bulletFooterDiv);          
        });
      });

      document.addEventListener("turbo:before-stream-render", function(event) {
        const template = event.detail.newStream.querySelector("template");
        const templateContent = template.content;
        const bulletFooterDiv = templateContent.querySelector("details#bullet-footer > div");
        alertIfBulletWarning(bulletFooterDiv);
      });
    </script>
    <% end %>
```

<img width="456" alt="image" src="https://github.com/user-attachments/assets/74f77199-063e-40a3-bca2-8645fcb5310a">