### PR TITLE
Option to disable orms in configuration

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -36,6 +36,7 @@ module Bullet
     attr_writer :n_plus_one_query_enable,
                 :unused_eager_loading_enable,
                 :counter_cache_enable,
+                :disable_orms,
                 :stacktrace_includes,
                 :stacktrace_excludes,
                 :skip_html_injection
@@ -69,8 +70,8 @@ module Bullet
         reset_safelist
         unless orm_patches_applied
           self.orm_patches_applied = true
-          Bullet::Mongoid.enable if mongoid?
-          Bullet::ActiveRecord.enable if active_record?
+          Bullet::Mongoid.enable if mongoid? && !orm_disabled?(:mongoid)
+          Bullet::ActiveRecord.enable if active_record? && !orm_disabled?(:active_record)
         end
       end
     end
@@ -98,6 +99,10 @@ module Bullet
 
     def counter_cache_enable?
       enable? && !!@counter_cache_enable
+    end
+
+    def disable_orms
+      @disable_orms ||= []
     end
 
     def stacktrace_includes
@@ -266,6 +271,10 @@ module Bullet
 
     private
 
+    def orm_disabled?(orm)
+      @disabled_orms&.include?(orm)
+    end
+    
     def for_each_active_notifier_with_notification
       UniformNotifier.active_notifiers.each do |notifier|
         notification_collector.collection.each do |notification|

--- a/spec/bullet_spec.rb
+++ b/spec/bullet_spec.rb
@@ -72,6 +72,36 @@ describe Bullet, focused: true do
     end
   end
 
+  describe '#disable_orms' do
+    it 'should return empty array by default' do
+      expect(subject.disable_orms).to eq([])
+    end
+
+    it 'should not enable disabled orm' do
+      subject.disable_orms << :mongoid
+      expect(Bullet::Mongoid).not_to receive(:enable) if defined?(Bullet::Mongoid)
+      subject.enable = true
+    end
+
+    it 'should enable non-disabled orm' do
+      subject.disable_orms << :mongoid
+      expect(Bullet::ActiveRecord).to receive(:enable) if defined?(Bullet::ActiveRecord)
+      subject.enable = true
+    end
+  end
+
+  describe '#orm_disabled?' do
+    before { subject.disable_orms << :mongoid }
+
+    it 'should return true for disabled orm' do
+      expect(subject.send(:orm_disabled?, :mongoid)).to be true
+    end
+
+    it 'should return false for non-disabled orm' do
+      expect(subject.send(:orm_disabled?, :active_record)).to be false
+    end
+  end
+
   describe '#start?' do
     context 'when bullet is disabled' do
       before(:each) { Bullet.enable = false }


### PR DESCRIPTION
we have some rake task archiving data and saving on mongoid, primary database is postgres, mogoid is required: false by default on Gemfile, this setting cause us an error while running rake tasks since mongoid is not loaded before bullet.