### PR TITLE
Reduce mem allocations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,11 @@ jobs:
         ruby-version: 2.7
         bundler: 1
         bundler-cache: true
+    - name: Breakpoint if tests failed
+      if: failure()
+      uses: namespacelabs/breakpoint-action@v0
+      with:
+        duration: 30m
     - name: Run tests
       run: bundle exec rake
   test_rails_5:

--- a/lib/bullet/detector/association.rb
+++ b/lib/bullet/detector/association.rb
@@ -81,7 +81,7 @@ module Bullet
           Thread.current.thread_variable_get(:bullet_eager_loadings)
         end
 
-        # cal_stacks keeps stacktraces where querie-objects were called from.
+        # call_stacks keeps stacktraces where querie-objects were called from.
         # e.g. { 'Object:111' => [SomeProject/app/controllers/...] }
         def call_stacks
           Thread.current.thread_variable_get(:bullet_call_stacks)

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -27,7 +27,7 @@ module Bullet
           )
           if !excluded_stacktrace_path? && conditions_met?(object, associations)
             Bullet.debug('detect n + 1 query', "object: #{object.bullet_key}, associations: #{associations}")
-            create_notification caller_in_project(object.bullet_key), object.class.to_s, associations
+            create_notification(caller_in_project(object.bullet_key), object.class.to_s, associations)
           end
         end
 
@@ -38,16 +38,16 @@ module Bullet
           objects = Array.wrap(object_or_objects)
           class_names_match_regex = true
           primary_key_values_are_empty = true
-          keys_joined = ""
-          objects.each do |obj|
+
+          keys_joined = objects.map do |obj|
             unless obj.class.name =~ /^HABTM_/
               class_names_match_regex = false
             end
             unless obj.bullet_primary_key_value.nil?
               primary_key_values_are_empty = false
             end
-            keys_joined += "#{(keys_joined.empty? ? '' : ', ')}#{obj.bullet_key}"
-          end
+            obj.bullet_key
+          end.join(", ")
           unless class_names_match_regex || primary_key_values_are_empty
             Bullet.debug('Detector::NPlusOneQuery#add_possible_objects', "objects: #{keys_joined}")
             objects.each { |object| possible_objects.add object.bullet_key }

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -48,6 +48,7 @@ module Bullet
             end
             obj.bullet_key
           end.join(", ")
+
           unless class_names_match_regex || primary_key_values_are_empty
             Bullet.debug('Detector::NPlusOneQuery#add_possible_objects', "objects: #{keys_joined}")
             objects.each { |object| possible_objects.add object.bullet_key }

--- a/lib/bullet/ext/object.rb
+++ b/lib/bullet/ext/object.rb
@@ -4,22 +4,20 @@ module Bullet
   module Ext
     module Object
       refine ::Object do
+        attr_writer :bullet_key, :bullet_primary_key_value
+
         def bullet_key
-          "#{self.class}:#{bullet_primary_key_value}"
+          @bullet_key ||= "#{self.class}:#{bullet_primary_key_value}"
         end
 
         def bullet_primary_key_value
-          return if respond_to?(:persisted?) && !persisted?
+          @bullet_primary_key_value ||= begin
+            return if respond_to?(:persisted?) && !persisted?
 
-          if self.class.respond_to?(:primary_keys) && self.class.primary_keys
-            primary_key = self.class.primary_keys
-          elsif self.class.respond_to?(:primary_key) && self.class.primary_key
-            primary_key = self.class.primary_key
-          else
-            primary_key = :id
+            primary_key = self.class.try(:primary_keys) || self.class.try(:primary_key) || :id
+
+            bullet_join_potential_composite_primary_key(primary_key)
           end
-
-          bullet_join_potential_composite_primary_key(primary_key)
         end
 
         private

--- a/lib/bullet/ext/string.rb
+++ b/lib/bullet/ext/string.rb
@@ -4,13 +4,9 @@ module Bullet
   module Ext
     module String
       refine ::String do
-        attr_reader :bullet_class_name
-
         def bullet_class_name
-          @bullet_class_name ||= begin
-            last_colon = self.rindex(':')
-            last_colon ? self[0...last_colon] : self
-          end
+          last_colon = self.rindex(':')
+          last_colon ? self[0...last_colon].dup : self.dup
         end
       end
     end

--- a/lib/bullet/ext/string.rb
+++ b/lib/bullet/ext/string.rb
@@ -4,8 +4,13 @@ module Bullet
   module Ext
     module String
       refine ::String do
+        attr_reader :bullet_class_name
+
         def bullet_class_name
-          sub(/:[^:]*?$/, '')
+          @bullet_class_name ||= begin
+            last_colon = self.rindex(':')
+            last_colon ? self[0...last_colon] : self
+          end
         end
       end
     end

--- a/lib/bullet/stack_trace_filter.rb
+++ b/lib/bullet/stack_trace_filter.rb
@@ -7,7 +7,6 @@ using Bullet::Ext::Object
 module Bullet
   module StackTraceFilter
     VENDOR_PATH = '/vendor'
-    IS_RUBY_19 = Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
 
     # @param bullet_key[String] - use this to get stored call stack from call_stacks object.
     def caller_in_project(bullet_key = nil)
@@ -56,13 +55,12 @@ module Bullet
     def location_as_path(location)
       return location if location.is_a?(String)
 
-      IS_RUBY_19 ? location : location.absolute_path.to_s
+      location.absolute_path.to_s
     end
 
     def select_caller_locations(bullet_key = nil)
-      return caller.select { |caller_path| yield caller_path } if IS_RUBY_19
-
       call_stack = bullet_key ? call_stacks[bullet_key] : caller_locations
+
       call_stack.select { |location| yield location }
     end
   end

--- a/perf/benchmark.rb
+++ b/perf/benchmark.rb
@@ -30,10 +30,8 @@ end
 
 # create database bullet_benchmark;
 ActiveRecord::Base.establish_connection(
-  adapter: 'mysql2',
-  database: 'bullet_benchmark',
-  server: '/tmp/mysql.socket',
-  username: 'root'
+  adapter: 'sqlite3',
+  database: 'bullet_benchmark'
 )
 
 ActiveRecord::Base.connection.tables.each { |table| ActiveRecord::Base.connection.drop_table(table) }
@@ -81,7 +79,7 @@ Benchmark.bm(70) do |bm|
   bm.report("Querying & Iterating #{posts_size} Posts with #{comments_size} Comments and #{users_size} Users") do
     10.times do
       Bullet.start_request
-      Post.select('SQL_NO_CACHE *').includes(:user, comments: :user).each do |p|
+      Post.includes(:user, comments: :user).each do |p|
         p.title
         p.user.name
         p.comments.each do |c|

--- a/spec/bullet/detector/n_plus_one_query_spec.rb
+++ b/spec/bullet/detector/n_plus_one_query_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'ostruct'
 
 using Bullet::Ext::Object
 

--- a/spec/bullet/ext/object_spec.rb
+++ b/spec/bullet/ext/object_spec.rb
@@ -26,21 +26,21 @@ describe Object do
     end
 
     it 'should return primary key value' do
-      post = Post.first
       Post.primary_key = 'name'
+      post = Post.first
       expect(post.bullet_primary_key_value).to eq(post.name)
       Post.primary_key = 'id'
     end
 
     it 'should return value for multiple primary keys from the composite_primary_key gem' do
-      post = Post.first
       allow(Post).to receive(:primary_keys).and_return(%i[category_id writer_id])
+      post = Post.first
       expect(post.bullet_primary_key_value).to eq("#{post.category_id},#{post.writer_id}")
     end
 
     it 'should return value for multiple primary keys from ActiveRecord 7.1' do
-      post = Post.first
       allow(Post).to receive(:primary_key).and_return(%i[category_id writer_id])
+      post = Post.first
       expect(post.bullet_primary_key_value).to eq("#{post.category_id},#{post.writer_id}")
     end
 


### PR DESCRIPTION
As mentioned below, I'm unsure as to what is making the tests fail.

Benchmark:
Using a local projects page firing 42 queries and detecting one `include` missing:

On 8.0.0
```
allocated memory by gem
-----------------------------------
   3598454  activesupport-8.0.0.1
   1275662  bullet/lib
```

Patch:
```
allocated memory by gem
-----------------------------------
   3598454  activesupport-8.0.0.1
   1139414  bullet/lib
```

Running the benchmark:

8.0.0
```
1000 Posts with 10000 Comments and 100 Users       13.591269   0.893714  14.484983 ( 14.682978)
```

Patch:
```
1000 Posts with 10000 Comments and 100 Users        6.464706   0.390424   6.855130 (  7.152605)
```

Which is a surprising improvement, considering I was mostly aiming at reducing the memory usage. I suspect this will actually be more valuable than the 5% memory usage reduction for most people.

Happy for you to review the changes @flyerhzm 
I'm not sure how to solve the specs all failing at this time.

I believe there's still a fair bit on the table within the naive implementation for grabbing stack traces, we could for a start limit the size of the stack trace we grab by using `caller(0..n)` over `Thread.current.backtrace` or filter straight as we grab the content of the backtrace might do the trick too?