### PR TITLE
Require active_support's inflections module before requiring the delegation module

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/module/delegation'
 require 'set'
 require 'uniform_notifier'


### PR DESCRIPTION
When using bullet with Active Support on version 7.2 or greater, in a non-Rails project, an error is thrown during the initial load:
```
/Users/emil/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/activesupport-7.2.2.1/lib/active_support/delegation.rb:47:in `generate': uninitialized constant #<Class:ActiveSupport::Delegation>::Inflector (NameError)

          unless Inflector.safe_constantize(to.name).equal?(to)
                 ^^^^^^^^^
        from /Users/emil/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/activesupport-7.2.2.1/lib/active_support/core_ext/module/delegation.rb:161:in `delegate'
        from /Users/emil/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/bullet-7.2.0/lib/bullet.rb:53:in `singleton class'
        from /Users/emil/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/bullet-7.2.0/lib/bullet.rb:35:in `<module:Bullet>'
        from /Users/emil/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/bullet-7.2.0/lib/bullet.rb:11:in `<top (required)>'
```

This is due to a change in Rails which expects `active_support` to be required before any modules are cherry-picked: https://github.com/rails/rails/issues/52582.

This PR adds that require.