### PR TITLE
change Bullet's feature enable logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,6 @@ Bullet.unused_eager_loading_enable = false
 Bullet.counter_cache_enable        = false
 ```
 
-Note: When calling `Bullet.enable`, all other detectors are reset to their defaults (`true`) and need reconfiguring.
-
 ## Safe list
 
 Sometimes Bullet may notify you of query problems you don't care to fix, or

--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -64,7 +64,7 @@ module Bullet
     ].freeze
 
     def enable=(enable)
-      @enable = @n_plus_one_query_enable = @unused_eager_loading_enable = @counter_cache_enable = enable
+      @enable = enable
 
       if enable?
         reset_safelist
@@ -90,15 +90,15 @@ module Bullet
     end
 
     def n_plus_one_query_enable?
-      enable? && !!@n_plus_one_query_enable
+      enable? && (@n_plus_one_query_enable.nil? ? true : @n_plus_one_query_enable)
     end
 
     def unused_eager_loading_enable?
-      enable? && !!@unused_eager_loading_enable
+      enable? && (@unused_eager_loading_enable.nil? ? true : @unused_eager_loading_enable)
     end
 
     def counter_cache_enable?
-      enable? && !!@counter_cache_enable
+      enable? && (@counter_cache_enable.nil? ? true : @counter_cache_enable)
     end
 
     def stacktrace_includes


### PR DESCRIPTION
fix https://github.com/flyerhzm/bullet/issues/703

This pull request includes changes to the `lib/bullet.rb` file to improve the handling of feature enablement flags by introducing default values and refactoring the enablement checks.

Refactoring of feature enablement flags:

* [`lib/bullet.rb`](diffhunk://#diff-56e8066b5abe8aa4937fd79797e591694ca827264b1fc8510da50b65ad89f495L67-R71): Modified the `enable=` method to set default values for `@n_plus_one_query_enable`, `@unused_eager_loading_enable`, and `@counter_cache_enable` if they are not already set.
* [`lib/bullet.rb`](diffhunk://#diff-56e8066b5abe8aa4937fd79797e591694ca827264b1fc8510da50b65ad89f495L93-R117): Refactored the `n_plus_one_query_enable?`, `unused_eager_loading_enable?`, and `counter_cache_enable?` methods to use new helper methods (`default_n_plus_one_query_enable?`, `default_unused_eager_loading_enable?`, and `default_counter_cache_enable?`) for checking the default values.

---
> Note: When calling `Bullet.enable`, all other detectors are reset to their defaults (`true`) and need reconfiguring.

Is there any reason why it is set up [this](https://github.com/flyerhzm/bullet/blob/main/README.md?plain=1#L124)?

If there isn't any special reason, I think `@n_plus_one_query_enable`, `@unused_eager_loading_enable`, and `@counter_cache_enable` don't need to be reset. Since there's an `enable? &&` check in the function below, it seems there wouldn't be any impact.
- `def n_plus_one_query_enable?`
- `def unused_eager_loading_enable?`
- `def counter_cache_enable?`