### PR TITLE
Add CSP nonce for footer styles as well

### DIFF
--- a/spec/bullet/rack_spec.rb
+++ b/spec/bullet/rack_spec.rb
@@ -185,7 +185,7 @@ module Bullet
 
             _, headers, response = middleware.call('Content-Type' => 'text/html')
 
-            size = 56 + middleware.send(:footer_note).length + middleware.send(:xhr_script, nonce).length
+            size = 56 + middleware.send(:footer_note, nonce).length + middleware.send(:xhr_script, nonce).length
             expect(headers['Content-Length']).to eq(size.to_s)
           end
 
@@ -203,7 +203,42 @@ module Bullet
 
             _, headers, response = middleware.call('Content-Type' => 'text/html')
 
-            size = 56 + middleware.send(:footer_note).length + middleware.send(:xhr_script, nonce).length
+            size = 56 + middleware.send(:footer_note, nonce).length + middleware.send(:xhr_script, nonce).length
+            expect(headers['Content-Length']).to eq(size.to_s)
+          end
+
+          it 'should include CSP nonce in inline style if console_enabled and a CSP is applied' do
+            allow(Bullet).to receive(:add_footer).at_least(:once).and_return(true)
+            expect(Bullet).to receive(:console_enabled?).and_return(true)
+            allow(middleware).to receive(:xhr_script).and_call_original
+
+            nonce = '+t9/wTlgG6xbHxXYUaDNzQ=='
+            app.headers = {
+              'Content-Type' => 'text/html',
+              'Content-Security-Policy' => "default-src 'self' https:; style-src 'self' https: 'nonce-#{nonce}'"
+            }
+
+            _, headers, response = middleware.call('Content-Type' => 'text/html')
+
+            size = 56 + middleware.send(:footer_note, nonce).length + middleware.send(:xhr_script, nonce).length
+            expect(headers['Content-Length']).to eq(size.to_s)
+          end
+
+          it 'should include CSP nonce in inline style if console_enabled and a CSP (report only) is applied' do
+            allow(Bullet).to receive(:add_footer).at_least(:once).and_return(true)
+            expect(Bullet).to receive(:console_enabled?).and_return(true)
+            allow(middleware).to receive(:xhr_script).and_call_original
+
+            nonce = '+t9/wTlgG6xbHxXYUaDNzQ=='
+            app.headers = {
+              'Content-Type' => 'text/html',
+              'Content-Security-Policy-Report-Only' =>
+                "default-src 'self' https:; style-src 'self' https: 'nonce-#{nonce}'"
+            }
+
+            _, headers, response = middleware.call('Content-Type' => 'text/html')
+
+            size = 56 + middleware.send(:footer_note, nonce).length + middleware.send(:xhr_script, nonce).length
             expect(headers['Content-Length']).to eq(size.to_s)
           end
 


### PR DESCRIPTION
Bullet does not currently render its footer with the expected styles when Rails `content_security_policy` configuration is the following.

```ruby
Rails.application.configure do
  config.content_security_policy do |policy|
    # ...
    policy.script_src :self
    policy.style_src :self
  end
  config.content_security_policy_nonce_directives = %w[script-src style-src]
end
```

This Pull Request replaces **style attributes** with **style tags** containing the expected `nonce` when required in the Rack middleware.