### PR TITLE
Use middleware after initializers

### DIFF
--- a/lib/bullet.rb
+++ b/lib/bullet.rb
@@ -23,7 +23,7 @@ module Bullet
 
   if defined?(Rails::Railtie)
     class BulletRailtie < Rails::Railtie
-      initializer 'bullet.add_middleware' do |app|
+      initializer 'bullet.add_middleware', after: :load_config_initializers do |app|
         if defined?(ActionDispatch::ContentSecurityPolicy::Middleware) && Rails.application.config.content_security_policy && !app.config.api_only
           app.middleware.insert_before ActionDispatch::ContentSecurityPolicy::Middleware, Bullet::Rack
         else


### PR DESCRIPTION
## About

My app is adopting the Rails `Content-Security-Policy` header configuration and I began noticing that the injected javascript from Bullet started raising violations. From there, I checked out the source for the middleware and saw that CSP support exists.

The issue that became clear was the middleware was being added later in the middleware stack, despite the Railtie reading as if it's placing `Bullet::Rack` before `ActionDispatch::ContentSecurityPolicy::Middleware`.

Turned out that the initializers haven't run when this Railtie is ran, causing the `Rails.application.config.content_security_policy` to be `nil`.

Using `after: :load_config_initializers` avoids that issue and ensures the `content_security_policy` is present if one is defined.
