### PR TITLE
Fix bullet composite primary key retrieval

### DIFF
--- a/lib/bullet/ext/object.rb
+++ b/lib/bullet/ext/object.rb
@@ -26,10 +26,10 @@ module Bullet
         private
 
         def bullet_join_potential_composite_primary_key(primary_keys)
-          return send(primary_keys) unless primary_keys.is_a?(Enumerable)
+          return read_attribute(primary_keys) unless primary_keys.is_a?(Enumerable)
 
-          primary_keys.map { |primary_key| send primary_key }
-                      .join(',')
+          primary_keys.map { |primary_key| read_attribute primary_key }
+                      .compact.join(',')
         end
       end
     end

--- a/spec/bullet/ext/object_spec.rb
+++ b/spec/bullet/ext/object_spec.rb
@@ -38,6 +38,12 @@ describe Object do
       expect(post.bullet_primary_key_value).to eq("#{post.category_id},#{post.writer_id}")
     end
 
+    it 'should return empty value for multiple primary keys without values' do
+      allow(Post).to receive(:primary_keys).and_return(%i[category_id writer_id])
+      post = Post.select('1 as myfield').first
+      expect(post.bullet_primary_key_value).to eq("")
+    end
+
     if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('7.1')
       it 'should return value for multiple primary keys from ActiveRecord 7.1' do
         allow(Post).to receive(:primary_key).and_return(%i[category_id writer_id])


### PR DESCRIPTION
### Summary

Fixes https://github.com/flyerhzm/bullet/issues/749

When PK columns were not selected bullet
should not raise an exception and should
treat it as empty primary key.