### PR TITLE
Make `get_relation` private

### DIFF
--- a/lib/bullet/mongoid4x.rb
+++ b/lib/bullet/mongoid4x.rb
@@ -46,6 +46,8 @@ module Bullet
       ::Mongoid::Relations::Accessors.class_eval do
         alias_method :origin_get_relation, :get_relation
 
+        private
+
         def get_relation(name, metadata, object, reload = false)
           result = origin_get_relation(name, metadata, object, reload)
           Bullet::Detector::NPlusOneQuery.call_association(self, name) if metadata.macro !~ /embed/

--- a/lib/bullet/mongoid5x.rb
+++ b/lib/bullet/mongoid5x.rb
@@ -46,6 +46,8 @@ module Bullet
       ::Mongoid::Relations::Accessors.class_eval do
         alias_method :origin_get_relation, :get_relation
 
+        private
+
         def get_relation(name, metadata, object, reload = false)
           result = origin_get_relation(name, metadata, object, reload)
           Bullet::Detector::NPlusOneQuery.call_association(self, name) if metadata.macro !~ /embed/

--- a/lib/bullet/mongoid6x.rb
+++ b/lib/bullet/mongoid6x.rb
@@ -46,6 +46,8 @@ module Bullet
       ::Mongoid::Relations::Accessors.class_eval do
         alias_method :origin_get_relation, :get_relation
 
+        private
+
         def get_relation(name, metadata, object, reload = false)
           result = origin_get_relation(name, metadata, object, reload)
           Bullet::Detector::NPlusOneQuery.call_association(self, name) if metadata.macro !~ /embed/

--- a/lib/bullet/mongoid7x.rb
+++ b/lib/bullet/mongoid7x.rb
@@ -61,6 +61,8 @@ module Bullet
       ::Mongoid::Association::Accessors.class_eval do
         alias_method :origin_get_relation, :get_relation
 
+        private
+
         def get_relation(name, association, object, reload = false)
           result = origin_get_relation(name, association, object, reload)
           Bullet::Detector::NPlusOneQuery.call_association(self, name) unless association.embedded?

--- a/lib/bullet/mongoid8x.rb
+++ b/lib/bullet/mongoid8x.rb
@@ -46,6 +46,8 @@ module Bullet
       ::Mongoid::Association::Accessors.class_eval do
         alias_method :origin_get_relation, :get_relation
 
+        private
+
         def get_relation(name, association, object, reload = false)
           result = origin_get_relation(name, association, object, reload)
           unless association.embedded?

--- a/lib/bullet/mongoid9x.rb
+++ b/lib/bullet/mongoid9x.rb
@@ -61,6 +61,8 @@ module Bullet
       ::Mongoid::Association::Accessors.class_eval do
         alias_method :origin_get_relation, :get_relation
 
+        private
+
         def get_relation(name, association, object, reload = false)
           result = origin_get_relation(name, association, object, reload)
           Bullet::Detector::NPlusOneQuery.call_association(self, name) unless association.embedded?


### PR DESCRIPTION
This pull request restores the original visibility of Mongoid’s `get_relation` method to **private**.

Currently, requiring Bullet changes the visibility of `get_relation` from private to public because Bullet redefines it to patch its behavior.  
However, in Mongoid’s own implementation, `get_relation` has been private in **all versions from 4.x through 9.x**.
(see [v4.0.2](https://github.com/mongodb/mongoid/blob/v4.0.2/lib/mongoid/relations/accessors.rb#L78-L95), [v5.4.1](https://github.com/mongodb/mongoid/blob/v5.4.1/lib/mongoid/relations/accessors.rb#L77-L94), [v6.4.8](https://github.com/mongodb/mongoid/blob/v6.4.8/lib/mongoid/relations/accessors.rb#L77-L94), [v7.5.4](https://github.com/mongodb/mongoid/blob/v7.5.4/lib/mongoid/association/accessors.rb#L76-L92), [v8.1.11](https://github.com/mongodb/mongoid/blob/v8.1.11/lib/mongoid/association/accessors.rb#L91-L107), [v9.0.8](https://github.com/mongodb/mongoid/blob/v9.0.8/lib/mongoid/association/accessors.rb#L93-L109))

In typical Rails projects, Bullet is often included only in development environments:

```ruby
gem 'bullet', group: 'development'
```

This means that in development `get_relation` becomes public, while in production it remains private.

```
# When Bullet is required
document.get_relation(:user, document.associations[:user], nil) # => #<User _id: ...

# When Bullet is NOT required
document.get_relation(:user, document.associations[:user], nil) # raises NoMethodError (private method 'get_relation' called for ...)
```

If application code happens to rely on `get_relation`—even unintentionally—the issue will only surface after deployment, resulting in an unexpected error such as:

```
undefined method `get_relation'
```

This discrepancy between development and production is dangerous and can be avoided entirely by keeping the method’s visibility consistent with Mongoid’s original definition.

This change ensures Bullet’s patch respects Mongoid’s intended visibility.