### PR TITLE
Fix `Set#<<` corruption in `UnusedEagerLoading#add_eager_loadings`

### DIFF
--- a/lib/bullet/detector/unused_eager_loading.rb
+++ b/lib/bullet/detector/unused_eager_loading.rb
@@ -50,7 +50,7 @@ module Bullet
             if key_objects_overlap == k
               to_add << [k, associations]
             else
-              to_merge << [key_objects_overlap, (eager_loadings[k].dup << associations)]
+              to_merge << [key_objects_overlap, eager_loadings[k].dup.merge(Array.wrap(associations))]
 
               keys_without_objects = k - key_objects_overlap
               to_merge << [keys_without_objects, eager_loadings[k]]

--- a/spec/bullet/detector/unused_eager_loading_spec.rb
+++ b/spec/bullet/detector/unused_eager_loading_spec.rb
@@ -122,6 +122,28 @@ module Bullet
           expect(UnusedEagerLoading.send(:eager_loadings)).to be_include([@post.bullet_key], :association2)
           expect(UnusedEagerLoading.send(:eager_loadings)).to be_include([@post2.bullet_key], :association1)
         end
+
+        it 'should merge each association element when associations is an Array (not the Array itself)' do
+          # Regression test: ActiveRecord::Associations::JoinDependency#instantiate
+          # passes the per-record association set as `to_a`, i.e. an Array. When
+          # the eager_loadings group splits on partial overlap, the merge branch
+          # must add each Array element to the existing Set rather than the whole
+          # Array as a single element. Otherwise similarly_associated's strict
+          # `value == associations` comparison stops matching, every read goes
+          # uncredited, and the preload is reported as unused.
+          UnusedEagerLoading.add_eager_loadings([@post, @post2], %i[association1 association2])
+          UnusedEagerLoading.add_eager_loadings([@post2], %i[association1 association2])
+
+          eager_loadings = UnusedEagerLoading.send(:eager_loadings)
+          expect(eager_loadings).to be_include([@post.bullet_key], :association1)
+          expect(eager_loadings).to be_include([@post.bullet_key], :association2)
+          expect(eager_loadings).to be_include([@post2.bullet_key], :association1)
+          expect(eager_loadings).to be_include([@post2.bullet_key], :association2)
+
+          eager_loadings.registry.each_value do |value|
+            expect(value).to all(be_a(Symbol))
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #770

## Summary

When `add_eager_loadings` splits an existing eager-loadings group on partial overlap, the merge branch uses `Set#<<` to append the incoming `associations`:

```ruby
to_merge << [key_objects_overlap, (eager_loadings[k].dup << associations)]
```

If `associations` is an `Array` (which it is when called from `ActiveRecord::Associations::JoinDependency#instantiate` in `lib/bullet/active_record81.rb`, where it's passed as `eager_loadings_hash[objects.first].to_a`), `Set#<<` adds the whole Array as a single element rather than merging its contents. Subsequent `similarly_associated` lookups, which use a strict `value == associations` equality check, then fail to match clean symbol-only Sets, so reads are never credited and `unused_eager_loading` notifications fire for associations that were actually used.

## Fix

Use `Set#merge(Array.wrap(associations))`, which adds each Symbol to the existing Set whether the input is a Symbol or an Array of Symbols. The other site that adds to the registry (`Registry::Base#add`) already handles both cases.

## How to verify

There's two commits - the first adds a spec that fails due to the bug. The second commit adds the fix, so the new spec goes green.
