### PR TITLE
Fix false-positive "USE eager loading" for polymorphic, but absent, relations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Skip N+1 detection for optional polymorphic `belongs_to` whose `*_type` column is nil. ActiveRecord short-circuits the reader to nil without issuing SQL, so the access cannot represent an N+1 query and preloading would be a no-op.
+
 ## 8.1.1 (04/23/2026)
 
 * Fix ActiveRecord 8.1 patch-level method signature compatibility; test against Rails 8.1.3.

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -19,6 +19,15 @@ module Bullet
           return unless object.bullet_primary_key_value
           return if inversed_objects.include?(object.bullet_key, associations)
 
+          # AR short-circuits a polymorphic belongs_to read to nil when the
+          # *_type column is nil — no SQL is issued, so this cannot be an N+1.
+          # Still record the call so a present preload isn't flagged as unused.
+          if optional_polymorphic_belongs_to_with_nil_type?(object, associations)
+            add_call_object_associations(object, associations)
+            call_stacks.add(object.bullet_key, caller_stack) if caller_stack
+            return
+          end
+
           add_call_object_associations(object, associations)
           call_stacks.add(object.bullet_key, caller_stack) if caller_stack
 
@@ -115,6 +124,19 @@ module Bullet
         end
 
         private
+
+        def optional_polymorphic_belongs_to_with_nil_type?(object, associations)
+          return false unless associations.is_a?(Symbol) || associations.is_a?(String)
+          return false unless object.class.respond_to?(:reflect_on_association)
+
+          reflection = object.class.reflect_on_association(associations.to_sym)
+          return false unless reflection
+          return false unless reflection.respond_to?(:polymorphic?) && reflection.polymorphic?
+          return false unless reflection.respond_to?(:foreign_type)
+
+          foreign_type = reflection.foreign_type
+          foreign_type && object.respond_to?(:[]) && object[foreign_type].nil?
+        end
 
         def create_notification(callers, klazz, associations)
           notify_associations = Array.wrap(associations) - Bullet.get_safelist_associations(:n_plus_one_query, klazz)

--- a/spec/integration/active_record/polymorphic_spec.rb
+++ b/spec/integration/active_record/polymorphic_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+if active_record?
+  describe Bullet::Detector::NPlusOneQuery, 'optional polymorphic belongs_to' do
+    context 'with nil _type column on every host record' do
+      it 'does not flag N+1 when accessed without preload' do
+        roles = Role.all.to_a
+        roles.each { |role| role.resource }
+
+        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
+
+        expect(Bullet::Detector::Association)
+          .not_to be_detecting_unpreloaded_association_for(Role, :resource)
+        expect(Bullet::Detector::Association)
+          .not_to be_has_unused_preload_associations
+      end
+
+      it 'does not flag N+1 when accessed after preload' do
+        roles = Role.preload(:resource).to_a
+        roles.each { |role| role.resource }
+
+        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
+
+        expect(Bullet::Detector::Association)
+          .not_to be_detecting_unpreloaded_association_for(Role, :resource)
+        expect(Bullet::Detector::Association)
+          .not_to be_has_unused_preload_associations
+      end
+    end
+
+    context 'with non-nil _type column on host records' do
+      before do
+        post_id = Post.connection.select_value('SELECT id FROM posts LIMIT 1')
+        Role.connection.execute(
+          "UPDATE roles SET resource_type = 'Post', resource_id = #{post_id}"
+        )
+        Bullet.end_request
+        Bullet.start_request
+      end
+
+      after do
+        Role.connection.execute('UPDATE roles SET resource_type = NULL, resource_id = NULL')
+      end
+
+      it 'still flags N+1 when accessed without preload' do
+        roles = Role.all.to_a
+        roles.each { |role| role.resource }
+
+        expect(Bullet::Detector::Association)
+          .to be_detecting_unpreloaded_association_for(Role, :resource)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Bullet isn't recognizing an ActiveRecord short-circuit optimization, and mistakenly tells you "USE eager loading", even if you did.

```
class Book
  belongs_to :author, polymorphic: true
end

Book.update_all(author: nil)
Book.preload(:author).map(&:author) # Bullet raises, but we did the right thing
```

When ActiveRecord sees that the `*_type` column is nil for all values, it doesn't do a SQL lookup (in fact, it cannot do a SQL lookup). But, at the same time, it does not flip `loaded?` to true. This confuses Bullet.

I fixed this by adding a guard in NPlusOneQuery.call_association that records the call (so a present preload is not re-flagged as unused by the sibling detector) but skips N+1 detection when the reflection is polymorphic and the owner's foreign_type column is nil.