### PR TITLE
Handle inversed polymorphic belongs_to false positives

### DIFF
--- a/lib/bullet/active_record4.rb
+++ b/lib/bullet/active_record4.rb
@@ -166,10 +166,8 @@ module Bullet
         def reader(force_reload = false)
           result = origin_reader(force_reload)
           if Bullet.start?
-            unless @inversed
-              Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name)
-              Bullet::Detector::NPlusOneQuery.add_possible_objects(result)
-            end
+            Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name, inversed: @inversed)
+            Bullet::Detector::NPlusOneQuery.add_possible_objects(result) unless @inversed
           end
           result
         end

--- a/lib/bullet/active_record41.rb
+++ b/lib/bullet/active_record41.rb
@@ -134,7 +134,7 @@ module Bullet
         # call one to many associations
         alias_method :origin_load_target, :load_target
         def load_target
-          Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name) if Bullet.start? && !@inversed
+          Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name, inversed: @inversed) if Bullet.start?
           origin_load_target
         end
 
@@ -159,9 +159,9 @@ module Bullet
         def reader(force_reload = false)
           result = origin_reader(force_reload)
           if Bullet.start?
-            if @owner.class.name !~ /^HABTM_/ && !@inversed
-              Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name)
-              Bullet::Detector::NPlusOneQuery.add_possible_objects(result)
+            if @owner.class.name !~ /^HABTM_/
+              Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name, inversed: @inversed)
+              Bullet::Detector::NPlusOneQuery.add_possible_objects(result) unless @inversed
             end
           end
           result

--- a/lib/bullet/active_record42.rb
+++ b/lib/bullet/active_record42.rb
@@ -179,7 +179,7 @@ module Bullet
           records = origin_load_target
 
           if Bullet.start?
-            Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name) unless @inversed
+            Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name, inversed: @inversed)
             if records.first.class.name !~ /^HABTM_/
               if records.size > 1
                 Bullet::Detector::NPlusOneQuery.add_possible_objects(records)
@@ -215,13 +215,14 @@ module Bullet
           result = origin_reader(force_reload)
 
           if Bullet.start?
-            if @owner.class.name !~ /^HABTM_/ && !@inversed
-              Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name)
-
-              if Bullet::Detector::NPlusOneQuery.impossible?(@owner)
-                Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
-              else
-                Bullet::Detector::NPlusOneQuery.add_possible_objects(result) if result
+            if @owner.class.name !~ /^HABTM_/
+              Bullet::Detector::NPlusOneQuery.call_association(@owner, @reflection.name, inversed: @inversed)
+              unless @inversed
+                if Bullet::Detector::NPlusOneQuery.impossible?(@owner)
+                  Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
+                else
+                  Bullet::Detector::NPlusOneQuery.add_possible_objects(result) if result
+                end
               end
             end
           end

--- a/lib/bullet/active_record5.rb
+++ b/lib/bullet/active_record5.rb
@@ -202,7 +202,7 @@ module Bullet
                   end
                 end
               end
-              Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name) unless @inversed
+              Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name, inversed: @inversed)
               if records.first.class.name !~ /^HABTM_/
                 if records.size > 1
                   Bullet::Detector::NPlusOneQuery.add_possible_objects(records)
@@ -237,13 +237,14 @@ module Bullet
             result = super()
 
             if Bullet.start?
-              if owner.class.name !~ /^HABTM_/ && !@inversed
-                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name)
-
-                if Bullet::Detector::NPlusOneQuery.impossible?(owner)
-                  Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
-                else
-                  Bullet::Detector::NPlusOneQuery.add_possible_objects(result) if result
+              if owner.class.name !~ /^HABTM_/
+                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name, inversed: @inversed)
+                unless @inversed
+                  if Bullet::Detector::NPlusOneQuery.impossible?(owner)
+                    Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
+                  else
+                    Bullet::Detector::NPlusOneQuery.add_possible_objects(result) if result
+                  end
                 end
               end
             end

--- a/lib/bullet/active_record52.rb
+++ b/lib/bullet/active_record52.rb
@@ -173,7 +173,7 @@ module Bullet
                   end
                 end
               end
-              Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name) unless @inversed
+              Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name, inversed: @inversed)
               if records.first.class.name !~ /^HABTM_/
                 if records.size > 1
                   Bullet::Detector::NPlusOneQuery.add_possible_objects(records)
@@ -208,24 +208,27 @@ module Bullet
             result = super()
 
             if Bullet.start?
-              if owner.class.name !~ /^HABTM_/ && !@inversed
-                if is_a? ::ActiveRecord::Associations::ThroughAssociation
-                  Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
-                  association = owner.association reflection.through_reflection.name
-                  Array.wrap(association.target).each do |through_record|
-                    Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
-                  end
+              if owner.class.name !~ /^HABTM_/
+                unless @inversed
+                  if is_a? ::ActiveRecord::Associations::ThroughAssociation
+                    Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
+                    association = owner.association reflection.through_reflection.name
+                    Array.wrap(association.target).each do |through_record|
+                      Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+                    end
 
-                  if reflection.through_reflection != through_reflection
-                    Bullet::Detector::NPlusOneQuery.call_association(owner, through_reflection.name)
+                    if reflection.through_reflection != through_reflection
+                      Bullet::Detector::NPlusOneQuery.call_association(owner, through_reflection.name)
+                    end
                   end
                 end
-                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name)
-
-                if Bullet::Detector::NPlusOneQuery.impossible?(owner)
-                  Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
-                else
-                  Bullet::Detector::NPlusOneQuery.add_possible_objects(result) if result
+                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name, inversed: @inversed)
+                unless @inversed
+                  if Bullet::Detector::NPlusOneQuery.impossible?(owner)
+                    Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
+                  else
+                    Bullet::Detector::NPlusOneQuery.add_possible_objects(result) if result
+                  end
                 end
               end
             end

--- a/lib/bullet/active_record60.rb
+++ b/lib/bullet/active_record60.rb
@@ -200,7 +200,11 @@ module Bullet
                   end
                 end
               end
-              Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name) unless @inversed
+              if @inversed
+                Bullet::Detector::Association.add_call_object_associations(owner, reflection.name)
+              else
+                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name)
+              end
               if records.first.class.name !~ /^HABTM_/
                 if records.size > 1
                   Bullet::Detector::NPlusOneQuery.add_possible_objects(records)
@@ -235,24 +239,27 @@ module Bullet
             result = super()
 
             if Bullet.start?
-              if owner.class.name !~ /^HABTM_/ && !@inversed
-                if is_a? ::ActiveRecord::Associations::ThroughAssociation
-                  Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
-                  association = owner.association(reflection.through_reflection.name)
-                  Array.wrap(association.target).each do |through_record|
-                    Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
-                  end
+              if owner.class.name !~ /^HABTM_/
+                unless @inversed
+                  if is_a? ::ActiveRecord::Associations::ThroughAssociation
+                    Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
+                    association = owner.association(reflection.through_reflection.name)
+                    Array.wrap(association.target).each do |through_record|
+                      Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+                    end
 
-                  if reflection.through_reflection != through_reflection
-                    Bullet::Detector::NPlusOneQuery.call_association(owner, through_reflection.name)
+                    if reflection.through_reflection != through_reflection
+                      Bullet::Detector::NPlusOneQuery.call_association(owner, through_reflection.name)
+                    end
                   end
                 end
-                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name)
-
-                if Bullet::Detector::NPlusOneQuery.impossible?(owner)
-                  Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
-                else
-                  Bullet::Detector::NPlusOneQuery.add_possible_objects(result) if result
+                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name, inversed: @inversed)
+                unless @inversed
+                  if Bullet::Detector::NPlusOneQuery.impossible?(owner)
+                    Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
+                  else
+                    Bullet::Detector::NPlusOneQuery.add_possible_objects(result) if result
+                  end
                 end
               end
             end

--- a/lib/bullet/active_record61.rb
+++ b/lib/bullet/active_record61.rb
@@ -200,7 +200,11 @@ module Bullet
                   end
                 end
               end
-              Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name) unless @inversed
+              if @inversed
+                Bullet::Detector::Association.add_call_object_associations(owner, reflection.name)
+              else
+                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name)
+              end
               if records.first.class.name !~ /^HABTM_/
                 if records.size > 1
                   Bullet::Detector::NPlusOneQuery.add_possible_objects(records)
@@ -235,24 +239,27 @@ module Bullet
             result = super()
 
             if Bullet.start?
-              if owner.class.name !~ /^HABTM_/ && !@inversed
-                if is_a? ::ActiveRecord::Associations::ThroughAssociation
-                  Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
-                  association = owner.association(reflection.through_reflection.name)
-                  Array.wrap(association.target).each do |through_record|
-                    Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
-                  end
+              if owner.class.name !~ /^HABTM_/
+                unless @inversed
+                  if is_a? ::ActiveRecord::Associations::ThroughAssociation
+                    Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.through_reflection.name)
+                    association = owner.association(reflection.through_reflection.name)
+                    Array.wrap(association.target).each do |through_record|
+                      Bullet::Detector::NPlusOneQuery.call_association(through_record, source_reflection.name)
+                    end
 
-                  if reflection.through_reflection != through_reflection
-                    Bullet::Detector::NPlusOneQuery.call_association(owner, through_reflection.name)
+                    if reflection.through_reflection != through_reflection
+                      Bullet::Detector::NPlusOneQuery.call_association(owner, through_reflection.name)
+                    end
                   end
                 end
-                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name)
-
-                if Bullet::Detector::NPlusOneQuery.impossible?(owner)
-                  Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
-                else
-                  Bullet::Detector::NPlusOneQuery.add_possible_objects(result) if result
+                Bullet::Detector::NPlusOneQuery.call_association(owner, reflection.name, inversed: @inversed)
+                unless @inversed
+                  if Bullet::Detector::NPlusOneQuery.impossible?(owner)
+                    Bullet::Detector::NPlusOneQuery.add_impossible_object(result) if result
+                  else
+                    Bullet::Detector::NPlusOneQuery.add_possible_objects(result) if result
+                  end
                 end
               end
             end

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -17,19 +17,14 @@ module Bullet
           return unless Bullet.start?
           return unless Bullet.n_plus_one_query_enable?
           return unless object.bullet_primary_key_value
-          return if inversed_objects.include?(object.bullet_key, associations)
 
-          # AR short-circuits a polymorphic belongs_to read to nil when the
-          # *_type column is nil — no SQL is issued, so this cannot be an N+1.
-          # Still record the call so a present preload isn't flagged as unused.
-          if optional_polymorphic_belongs_to_with_nil_type?(object, associations)
-            add_call_object_associations(object, associations)
-            call_stacks.add(object.bullet_key, caller_stack) if caller_stack
-            return
-          end
-
+          # Record before early-returns so legitimate reads that bypass SQL
+          # (inversed, nil-polymorphic) aren't flagged as unused preloads.
           add_call_object_associations(object, associations)
           call_stacks.add(object.bullet_key, caller_stack) if caller_stack
+
+          return if inversed_objects.include?(object.bullet_key, associations)
+          return if optional_polymorphic_belongs_to_with_nil_type?(object, associations)
 
           Bullet.debug(
             'Detector::NPlusOneQuery#call_association',

--- a/lib/bullet/detector/n_plus_one_query.rb
+++ b/lib/bullet/detector/n_plus_one_query.rb
@@ -13,7 +13,7 @@ module Bullet
         # first, it keeps this method call for object.association.
         # then, it checks if this associations call is unpreload.
         #   if it is, keeps this unpreload associations and caller.
-        def call_association(object, associations, caller_stack = nil)
+        def call_association(object, associations, caller_stack = nil, inversed: false)
           return unless Bullet.start?
           return unless Bullet.n_plus_one_query_enable?
           return unless object.bullet_primary_key_value
@@ -23,6 +23,7 @@ module Bullet
           add_call_object_associations(object, associations)
           call_stacks.add(object.bullet_key, caller_stack) if caller_stack
 
+          return if inversed
           return if inversed_objects.include?(object.bullet_key, associations)
           return if optional_polymorphic_belongs_to_with_nil_type?(object, associations)
 

--- a/spec/integration/active_record/polymorphic_spec.rb
+++ b/spec/integration/active_record/polymorphic_spec.rb
@@ -51,6 +51,21 @@ if active_record?
         expect(Bullet::Detector::Association)
           .to be_detecting_unpreloaded_association_for(Role, :resource)
       end
+
+      it 'does not flag UnusedEagerLoading when an inversed polymorphic belongs_to is accessed' do
+        Post.preload(roles: :resource).each do |post|
+          post.roles.each { |role| role.resource }
+        end
+
+        Bullet::Detector::UnusedEagerLoading.check_unused_preload_associations
+
+        expect(Bullet::Detector::Association)
+          .not_to be_unused_preload_associations_for(Role, :resource)
+        expect(Bullet::Detector::Association)
+          .not_to be_has_unused_preload_associations
+        expect(Bullet::Detector::Association)
+          .not_to be_detecting_unpreloaded_association_for(Role, :resource)
+      end
     end
   end
 end

--- a/spec/models/post.rb
+++ b/spec/models/post.rb
@@ -4,6 +4,7 @@ class Post < ActiveRecord::Base
   belongs_to :category, inverse_of: :posts
   belongs_to :writer
   has_many :comments, inverse_of: :post
+  has_many :roles, as: :resource, inverse_of: :resource
   has_and_belongs_to_many :deals
 
   validates :category, presence: true


### PR DESCRIPTION
Bullet was raising a false-positive UnusedEagerLoading warning for polymorphic belongs_to associations that were actually being used. This only affected situations with an inverse back-reference (e.g. has_many :foo, as: :bar, inverse_of: :bar).

Rails’ preloader called inversed_from on the owner, which caused NPlusOneQuery.call_association to silently drop the subsequent legitimate access from its tracking. The preload looked unused even though the code did read the association.

@flyerhzm Sorry for the double-PR here! Thanks for taking a look.

